### PR TITLE
Add support for YAML tags

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,12 +2,21 @@
 
 This document lists YAML 1.2 specification features that are not yet implemented in yaml-edit.
 
+## Recent Progress (Updated 2025-08-10)
+
+Major features recently implemented:
+- ✅ **Anchors & Aliases** - Full support for anchor definitions and alias references with preservation
+- ✅ **Escape Sequences** - Complete implementation including Unicode escapes, control characters, and line folding
+- ✅ **YAML Directives** - Support for YAML version and TAG directives with preservation
+- ✅ **Merge Keys** - Basic parsing and preservation of merge key syntax (`<<:`)
+- ✅ **Tags and Explicit Typing** - Complete support for local tags, global tags, non-specific tags, and custom tags with safe value extraction
+
 ## High Priority (Common YAML Features)
 
 ### 1. Anchors & Aliases
-- [ ] Anchor definitions (`&anchor_name`)
-- [ ] Alias references (`*anchor_name`)
-- [ ] Preserve anchors/aliases during editing
+- [x] Anchor definitions (`&anchor_name`)
+- [x] Alias references (`*anchor_name`)
+- [x] Preserve anchors/aliases during editing
 - [ ] Handle circular references safely
 
 ### 2. Multi-line Scalar Styles
@@ -18,19 +27,19 @@ This document lists YAML 1.2 specification features that are not yet implemented
 - [ ] Block scalar content parsing with proper line break handling
 
 ### 3. Tags and Explicit Typing
-- [ ] Local tags (`!custom`)
-- [ ] Global tags (`!!str`, `!!int`, `!!float`, `!!bool`, `!!null`)
-- [ ] Tag shorthand declarations
-- [ ] Non-specific tags (`!` and `!!`)
-- [ ] Preserve tags during editing
-- [ ] Custom tag support
+- [x] Local tags (`!custom`)
+- [x] Global tags (`!!str`, `!!int`, `!!float`, `!!bool`, `!!null`)
+- [x] Tag shorthand declarations (via TAG directives)
+- [x] Non-specific tags (`!` and `!!`)
+- [x] Preserve tags during editing
+- [x] Custom tag support
 
 ### 4. Escape Sequences in Strings
-- [ ] Unicode escapes (`\xNN`, `\uNNNN`, `\UNNNNNNNN`)
-- [ ] Control character escapes (`\n`, `\r`, `\t`, `\b`, etc.)
-- [ ] Escaped quotes in quoted strings
-- [ ] Line folding in double-quoted strings
-- [ ] Escaped line breaks
+- [x] Unicode escapes (`\xNN`, `\uNNNN`, `\UNNNNNNNN`)
+- [x] Control character escapes (`\n`, `\r`, `\t`, `\b`, etc.)
+- [x] Escaped quotes in quoted strings
+- [x] Line folding in double-quoted strings
+- [x] Escaped line breaks
 
 ## Medium Priority (Less Common Features)
 
@@ -41,14 +50,14 @@ This document lists YAML 1.2 specification features that are not yet implemented
 - [ ] Proper parsing and editing of complex keys
 
 ### 6. Directives
-- [ ] YAML version directive (`%YAML 1.2`)
-- [ ] TAG directives (`%TAG ! prefix`)
+- [x] YAML version directive (`%YAML 1.2`)
+- [x] TAG directives (`%TAG ! prefix`)
 - [ ] Reserved directives
-- [ ] Directive end marker (`---`)
-- [ ] Preserve directives during editing
+- [x] Directive end marker (`---`)
+- [x] Preserve directives during editing
 
 ### 7. Special Collections
-- [ ] Merge keys (`<<`) for key merging
+- [x] Merge keys (`<<`) for key merging (basic parsing/preservation)
 - [ ] Sets (`!!set`)
 - [ ] Ordered mappings (`!!omap`)
 - [ ] Pairs (`!!pairs`)

--- a/examples/tag_test.rs
+++ b/examples/tag_test.rs
@@ -1,0 +1,50 @@
+use std::str::FromStr;
+use yaml_edit::Yaml;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let yaml_content = r#"# Test different types of tags
+local_tag: !custom value
+global_tag: !!str hello
+builtin_int: !!int 123
+builtin_bool: !!bool true
+non_specific: ! bare_value
+non_specific_global: !! another_value
+quoted_tagged: !tag "quoted string""#;
+
+    println!("Original YAML:");
+    println!("{}", yaml_content);
+
+    // Parse the YAML
+    match Yaml::from_str(yaml_content) {
+        Ok(yaml) => {
+            println!("\nParsed and formatted YAML:");
+            println!("{}", yaml);
+
+            // Check the actual values
+            if let Some(doc) = yaml.document() {
+                println!("\nActual values:");
+
+                let test_keys = [
+                    "local_tag",
+                    "global_tag",
+                    "builtin_int",
+                    "builtin_bool",
+                    "non_specific",
+                    "non_specific_global",
+                    "quoted_tagged",
+                ];
+
+                for key in &test_keys {
+                    if let Some(value) = doc.get_string(key) {
+                        println!("{}: {:?}", key, value);
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            println!("\nParsing error: {}", e);
+        }
+    }
+
+    Ok(())
+}

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -16,6 +16,8 @@ pub enum SyntaxKind {
     MAPPING,
     /// A YAML scalar value
     SCALAR,
+    /// A YAML tagged scalar (tag + value)
+    TAGGED_SCALAR,
     /// Parse error marker
     ERROR,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use parse::Parse;
 pub use rowan::TextRange;
 pub use scalar::{ScalarStyle, ScalarValue};
 pub use value::YamlValue;
-pub use yaml::{Directive, Document, Lang, Mapping, Scalar, Sequence, Yaml};
+pub use yaml::{Directive, Document, Lang, Mapping, Scalar, Sequence, TaggedScalar, Yaml};
 
 /// A positioned parse error containing location information.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -647,7 +647,7 @@ mod tests {
     }
 
     #[test]
-    fn test_escape_sequences_unicode_u_uppercase() {
+    fn test_escape_sequences_unicode_capital_u() {
         // Test \UNNNNNNNN escape sequences
         assert_eq!(ScalarValue::parse_escape_sequences("\\U00000041"), "A"); // 0x00000041 = 'A'
         assert_eq!(ScalarValue::parse_escape_sequences("\\U0001F603"), "😃"); // Smiley emoji


### PR DESCRIPTION
Implements complete YAML tag support including:
- Local tags (\!custom)
- Global tags (\!\!str, \!\!int, \!\!float, \!\!bool, \!\!null)
- Non-specific tags (\! and \!\!)
- Custom tag formats

The implementation adds a TAGGED_SCALAR syntax kind and TaggedScalar AST node to properly handle tags at the syntax tree level. Values are safely extracted through AST traversal rather than string manipulation.