### PR TITLE
Simplify lexer and parser implementation

### DIFF
--- a/examples/custom_schema.rs
+++ b/examples/custom_schema.rs
@@ -151,7 +151,7 @@ fn port_validation_example() {
         .allow_type(ScalarType::Integer)
         .with_validator(ScalarType::Integer, |value, _path| {
             if let Ok(port) = value.parse::<u16>() {
-                if port >= 1024 && port <= 65535 {
+                if (1024..=65535).contains(&port) {
                     CustomValidationResult::Valid
                 } else {
                     CustomValidationResult::invalid(
@@ -227,7 +227,7 @@ fn config_validation_example() {
         })
         .with_validator(ScalarType::Integer, |value, _path| {
             if let Ok(num) = value.parse::<i32>() {
-                if num >= 0 && num <= 10000 {
+                if (0..=10000).contains(&num) {
                     CustomValidationResult::Valid
                 } else {
                     CustomValidationResult::invalid(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1405,7 +1405,7 @@ email: "not-an-email"
             .allow_type(ScalarType::Integer)
             .with_validator(ScalarType::Integer, |value, _path| {
                 if let Ok(port) = value.parse::<u16>() {
-                    if port >= 1024 && port <= 65535 {
+                    if (1024..=65535).contains(&port) {
                         CustomValidationResult::Valid
                     } else {
                         CustomValidationResult::invalid(

--- a/tests/invalid_yaml_handling.rs
+++ b/tests/invalid_yaml_handling.rs
@@ -1,6 +1,5 @@
-use rowan::ast::AstNode;
 use std::str::FromStr;
-use yaml_edit::{Mapping, Scalar, Yaml};
+use yaml_edit::Yaml;
 
 #[test]
 fn test_invalid_colon_in_plain_scalar() {
@@ -82,7 +81,7 @@ fn test_invalid_bracket_colon_combination() {
             // This is the most spec-compliant result
             let error_str = format!("{:?}", e);
             println!("Got expected error: {}", error_str);
-            assert!(error_str.len() > 0, "Should have an error message");
+            assert!(!error_str.is_empty(), "Should have an error message");
         }
     }
 }

--- a/tests/parsing_bugs.rs
+++ b/tests/parsing_bugs.rs
@@ -444,11 +444,11 @@ another_key: value
     // Verify each item is a mapping with the expected structure
     for (i, item) in item_vec.iter().enumerate() {
         let item_mapping =
-            Mapping::cast(item.clone()).expect(&format!("Item {} should be a mapping", i));
+            Mapping::cast(item.clone()).unwrap_or_else(|| panic!("Item {} should be a mapping", i));
         let id = item_mapping
             .get("id")
             .and_then(Scalar::cast)
-            .expect(&format!("Item {} should have id", i));
+            .unwrap_or_else(|| panic!("Item {} should have id", i));
         assert_eq!(id.as_string(), (i + 1).to_string());
     }
 


### PR DESCRIPTION
- Consolidate special character checking in lexer using a single function with exclusions
- Introduce skip_tokens helper to reduce code duplication in parser
- Remove unused methods and fields from parser
- Apply cargo fmt and clippy fixes