### PR TITLE
Fix Sequence::push indentation bug for deeply nested nodes

### DIFF
--- a/src/nodes/mapping.rs
+++ b/src/nodes/mapping.rs
@@ -144,7 +144,19 @@ impl MappingEntry {
         // Build new VALUE node, preserving any inline comment from the old value
         let mut value_builder = GreenNodeBuilder::new();
         value_builder.start_node(SyntaxKind::VALUE.into());
-        new_value.build_content(&mut value_builder, 0, flow_context);
+        
+        // Detect indentation from parent mapping
+        let mut indent = 0;
+        if let Some(parent) = self.0.parent() {
+            if let Some(mapping) = Mapping::cast(parent) {
+                indent = mapping.detect_indentation_level();
+            }
+        }
+        if indent == 0 {
+            indent = 2; // Default fallback
+        }
+
+        new_value.build_content(&mut value_builder, indent, flow_context);
 
         // Find the old VALUE node and extract trailing whitespace + comment
         for child in self.0.children_with_tokens() {

--- a/src/nodes/mapping.rs
+++ b/src/nodes/mapping.rs
@@ -78,6 +78,7 @@ impl MappingEntry {
         value: impl crate::AsYaml,
         flow_context: bool,
         use_explicit_key: bool,
+        indent: usize,
     ) -> Self {
         let mut builder = GreenNodeBuilder::new();
         builder.start_node(SyntaxKind::MAPPING_ENTRY.into());
@@ -111,14 +112,14 @@ impl MappingEntry {
                 builder.token(SyntaxKind::WHITESPACE.into(), " ");
                 // Note: TAGGED_NODE values (!!set, !!omap, !!pairs) are inline but may
                 // end with newlines from their block-style content
-                value.build_content(&mut builder, 0, flow_context)
+                value.build_content(&mut builder, indent, flow_context)
             }
             // Block mappings and sequences start on new line but don't get pre-indented
             // They handle their own indentation via copy_node_content_with_indent
             (false, crate::as_yaml::YamlKind::Mapping)
             | (false, crate::as_yaml::YamlKind::Sequence) => {
                 builder.token(SyntaxKind::NEWLINE.into(), "\n");
-                value.build_content(&mut builder, 0, flow_context)
+                value.build_content(&mut builder, indent, flow_context)
             }
             // Block scalars (literal/folded) get newline and indent
             (false, _) => {
@@ -726,7 +727,8 @@ impl Mapping {
         }
 
         // Entry doesn't exist, create a new one
-        let new_entry = MappingEntry::new(key, value, flow_context, use_explicit_keys);
+        let indent = self.detect_indentation_level();
+        let new_entry = MappingEntry::new(key, value, flow_context, use_explicit_keys, if indent > 0 { indent } else { 2 });
         self.insert_entry_cst(&new_entry.0);
     }
 
@@ -766,8 +768,12 @@ impl Mapping {
         let insert_pos = count;
 
         // Add indentation if needed
-        let indent_level = self.detect_indentation_level();
-        if indent_level > 0 && count > 0 {
+        let mut indent_level = self.detect_indentation_level();
+        if indent_level == 0 {
+            // Try to detect from parent or default to 2
+            indent_level = 2; 
+        }
+        if count > 0 {
             let mut builder = rowan::GreenNodeBuilder::new();
             builder.start_node(SyntaxKind::ROOT.into());
             // Only add NEWLINE if we're NOT inserting before an existing trailing newline
@@ -1077,7 +1083,7 @@ impl Mapping {
             // Build the new entry with proper newline ownership
             let flow_context = self.is_flow_style();
             let use_explicit_keys = self.uses_explicit_keys();
-            let new_entry = MappingEntry::new(&key, &value, flow_context, use_explicit_keys).0;
+            let new_entry = MappingEntry::new(&key, &value, flow_context, use_explicit_keys, 0).0;
 
             // Insert after the target entry, ensuring it has a trailing newline
             if let Some(after_node) = insert_after_node {
@@ -2073,7 +2079,7 @@ impl Mapping {
         // Create the new mapping entry
         let flow_context = self.is_flow_style();
         let use_explicit_keys = self.uses_explicit_keys();
-        let new_entry = MappingEntry::new(&key, &value, flow_context, use_explicit_keys);
+        let new_entry = MappingEntry::new(&key, &value, flow_context, use_explicit_keys, 0);
 
         // Count existing entries to determine actual insertion position
         let entry_count = self.entries().count();

--- a/src/nodes/mapping.rs
+++ b/src/nodes/mapping.rs
@@ -156,6 +156,12 @@ impl MappingEntry {
             indent = 2; // Default fallback
         }
 
+        let is_block = !new_value.is_inline() && matches!(new_value.kind(), crate::as_yaml::YamlKind::Mapping | crate::as_yaml::YamlKind::Sequence);
+        if is_block {
+            value_builder.token(crate::lex::SyntaxKind::NEWLINE.into(), "\n");
+        } else {
+            value_builder.token(crate::lex::SyntaxKind::WHITESPACE.into(), " ");
+        }
         new_value.build_content(&mut value_builder, indent, flow_context);
 
         // Find the old VALUE node and extract trailing whitespace + comment

--- a/src/nodes/mapping.rs
+++ b/src/nodes/mapping.rs
@@ -159,6 +159,9 @@ impl MappingEntry {
         let is_block = !new_value.is_inline() && matches!(new_value.kind(), crate::as_yaml::YamlKind::Mapping | crate::as_yaml::YamlKind::Sequence);
         if is_block {
             value_builder.token(crate::lex::SyntaxKind::NEWLINE.into(), "\n");
+            if indent > 0 {
+                value_builder.token(crate::lex::SyntaxKind::INDENT.into(), &" ".repeat(indent));
+            }
         } else {
             value_builder.token(crate::lex::SyntaxKind::WHITESPACE.into(), " ");
         }

--- a/src/nodes/sequence.rs
+++ b/src/nodes/sequence.rs
@@ -82,22 +82,27 @@ impl Sequence {
     /// Mutates in place despite `&self` (see crate docs on interior mutability).
     pub fn push(&self, value: impl crate::AsYaml) {
         // Detect the indentation by looking at existing SEQUENCE_ENTRY nodes
-        let mut indentation = self
-            .0
-            .children_with_tokens()
-            .find_map(|child| {
-                child
-                    .into_token()
-                    .filter(|t| t.kind() == SyntaxKind::INDENT)
-                    .map(|t| t.text().to_string())
-            })
-            .unwrap_or_else(|| "  ".to_string());
-
-        // If no INDENT token found, look within SEQUENCE_ENTRY nodes
-        if indentation == "  " {
-            for child in self.0.children() {
-                if child.kind() == SyntaxKind::SEQUENCE_ENTRY {
-                    let tokens: Vec<_> = child.children_with_tokens().collect();
+        let mut indentation = "  ".to_string();
+        
+        // First try to find INDENT token directly in the sequence
+        if let Some(ind) = self.0.children_with_tokens().find_map(|child| {
+            child.into_token().filter(|t| t.kind() == SyntaxKind::INDENT).map(|t| t.text().to_string())
+        }) {
+            indentation = ind;
+        } else {
+            // Look for the first SEQUENCE_ENTRY and get its previous token
+            if let Some(first_entry) = self.0.children().find(|c| c.kind() == SyntaxKind::SEQUENCE_ENTRY) {
+                if let Some(prev_token) = first_entry.first_token().and_then(|t| t.prev_token()) {
+                    if prev_token.kind() == SyntaxKind::INDENT {
+                        indentation = prev_token.text().to_string();
+                    } else if prev_token.kind() == SyntaxKind::WHITESPACE {
+                        indentation = prev_token.text().to_string();
+                    }
+                }
+                
+                // If still not found, look inside the entry
+                if indentation == "  " {
+                    let tokens: Vec<_> = first_entry.children_with_tokens().collect();
                     for (i, token) in tokens.iter().enumerate() {
                         if let Some(t) = token.as_token() {
                             if t.kind() == SyntaxKind::WHITESPACE && i + 1 < tokens.len() {
@@ -109,9 +114,6 @@ impl Sequence {
                                 }
                             }
                         }
-                    }
-                    if !indentation.is_empty() && indentation != "  " {
-                        break;
                     }
                 }
             }
@@ -177,7 +179,9 @@ impl Sequence {
         builder.token(SyntaxKind::WHITESPACE.into(), " ");
 
         // Build the value content directly using AsYaml
-        let value_ends_with_newline = value.build_content(&mut builder, 0, false);
+        // Pass the correct indentation for the value (sequence indent + 2)
+        let value_indent = indentation.len() + 2;
+        let value_ends_with_newline = value.build_content(&mut builder, value_indent, false);
 
         // Add trailing newline only if the value doesn't already end with one
         // and if the last entry had one (preserves document style)
@@ -280,7 +284,8 @@ impl Sequence {
         builder.token(SyntaxKind::WHITESPACE.into(), " ");
 
         // Build the value content directly using AsYaml
-        value.build_content(&mut builder, 0, false);
+        let value_indent = indentation.len() + 2;
+        value.build_content(&mut builder, value_indent, false);
 
         builder.finish_node(); // SEQUENCE_ENTRY
         let new_entry = SyntaxNode::new_root_mut(builder.finish());
@@ -342,7 +347,14 @@ impl Sequence {
                                 {
                                     // Replace the value node with the new value built from AsYaml
                                     if !value_inserted {
-                                        value.build_content(&mut builder, 0, false);
+                                        // Try to find indentation from the current node's tokens
+                                        let mut indent = 2; // Default fallback
+                                        if let Some(prev) = n.first_token().and_then(|t| t.prev_token()) {
+                                            if prev.kind() == crate::lex::SyntaxKind::INDENT {
+                                                indent = prev.text().len() + 2;
+                                            }
+                                        }
+                                        value.build_content(&mut builder, indent, false);
                                         value_inserted = true;
                                     }
                                 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -419,11 +419,7 @@ fn set_path_on_mapping<V: crate::AsYaml>(mapping: &Mapping, segments: &[PathSegm
             if let Some(nested) = mapping.get_mapping(first_key) {
                 set_path_on_mapping(&nested, &segments[1..], value);
             } else {
-                let empty_mapping = crate::MappingBuilder::new()
-                    .build_document()
-                    .as_mapping()
-                    .expect("MappingBuilder always produces a mapping");
-                mapping.set(first_key, &empty_mapping);
+                mapping.set(first_key, crate::value::YamlValue::Mapping(Default::default()));
                 if let Some(nested) = mapping.get_mapping(first_key) {
                     set_path_on_mapping(&nested, &segments[1..], value);
                 }
@@ -433,11 +429,7 @@ fn set_path_on_mapping<V: crate::AsYaml>(mapping: &Mapping, segments: &[PathSegm
             if let Some(nested) = mapping.get_sequence(first_key) {
                 set_path_on_sequence(&nested, &segments[1..], value);
             } else {
-                let empty_seq = crate::SequenceBuilder::new()
-                    .build_document()
-                    .as_sequence()
-                    .expect("SequenceBuilder always produces a sequence");
-                mapping.set(first_key, &empty_seq);
+                mapping.set(first_key, crate::value::YamlValue::Sequence(Default::default()));
                 if let Some(nested) = mapping.get_sequence(first_key) {
                     set_path_on_sequence(&nested, &segments[1..], value);
                 }
@@ -468,11 +460,7 @@ fn set_path_on_sequence<V: crate::AsYaml>(seq: &crate::Sequence, segments: &[Pat
                 if let Some(nested) = item.as_mapping() {
                     set_path_on_mapping(&nested, &segments[1..], value);
                 } else {
-                    let empty_mapping = crate::MappingBuilder::new()
-                        .build_document()
-                        .as_mapping()
-                        .expect("MappingBuilder always produces a mapping");
-                    seq.set(index, &empty_mapping);
+                    seq.set(index, crate::value::YamlValue::Mapping(Default::default()));
                     if let Some(item) = seq.get(index) {
                         if let Some(nested) = item.as_mapping() {
                             set_path_on_mapping(&nested, &segments[1..], value);
@@ -484,11 +472,7 @@ fn set_path_on_sequence<V: crate::AsYaml>(seq: &crate::Sequence, segments: &[Pat
                 while seq.len() <= index {
                     seq.push(crate::scalar::ScalarValue::Null);
                 }
-                let empty_mapping = crate::MappingBuilder::new()
-                    .build_document()
-                    .as_mapping()
-                    .expect("MappingBuilder always produces a mapping");
-                seq.set(index, &empty_mapping);
+                seq.set(index, crate::value::YamlValue::Mapping(Default::default()));
                 if let Some(item) = seq.get(index) {
                     if let Some(nested) = item.as_mapping() {
                         set_path_on_mapping(&nested, &segments[1..], value);
@@ -501,11 +485,7 @@ fn set_path_on_sequence<V: crate::AsYaml>(seq: &crate::Sequence, segments: &[Pat
                 if let Some(nested) = item.as_sequence() {
                     set_path_on_sequence(&nested, &segments[1..], value);
                 } else {
-                    let empty_seq = crate::SequenceBuilder::new()
-                        .build_document()
-                        .as_sequence()
-                        .expect("SequenceBuilder always produces a sequence");
-                    seq.set(index, &empty_seq);
+                    seq.set(index, crate::value::YamlValue::Sequence(Default::default()));
                     if let Some(item) = seq.get(index) {
                         if let Some(nested) = item.as_sequence() {
                             set_path_on_sequence(&nested, &segments[1..], value);
@@ -517,11 +497,7 @@ fn set_path_on_sequence<V: crate::AsYaml>(seq: &crate::Sequence, segments: &[Pat
                 while seq.len() <= index {
                     seq.push(crate::scalar::ScalarValue::Null);
                 }
-                let empty_seq = crate::SequenceBuilder::new()
-                    .build_document()
-                    .as_sequence()
-                    .expect("SequenceBuilder always produces a sequence");
-                seq.set(index, &empty_seq);
+                seq.set(index, crate::value::YamlValue::Sequence(Default::default()));
                 if let Some(item) = seq.get(index) {
                     if let Some(nested) = item.as_sequence() {
                         set_path_on_sequence(&nested, &segments[1..], value);

--- a/src/path.rs
+++ b/src/path.rs
@@ -403,33 +403,131 @@ fn set_path_on_mapping<V: crate::AsYaml>(mapping: &Mapping, segments: &[PathSegm
         return;
     }
 
-    // First segment must be a key for mappings
     let first_key = match &segments[0] {
         PathSegment::Key(key) => key.as_str(),
-        PathSegment::Index(_) => return, // Can't set by index on a mapping
+        PathSegment::Index(_) => return,
     };
 
     if segments.len() == 1 {
-        // Base case: set directly
         mapping.set(first_key, value);
         return;
     }
 
-    // Try to navigate to existing nested mapping
-    if let Some(nested) = mapping.get_mapping(first_key) {
-        // Nested mapping exists, recurse
-        set_path_on_mapping(&nested, &segments[1..], value);
-    } else {
-        // Need to create intermediate structure
-        let empty_mapping = MappingBuilder::new()
-            .build_document()
-            .as_mapping()
-            .expect("MappingBuilder always produces a mapping");
-        mapping.set(first_key, &empty_mapping);
+    let next_segment = &segments[1];
+    match next_segment {
+        PathSegment::Key(_) => {
+            if let Some(nested) = mapping.get_mapping(first_key) {
+                set_path_on_mapping(&nested, &segments[1..], value);
+            } else {
+                let empty_mapping = crate::MappingBuilder::new()
+                    .build_document()
+                    .as_mapping()
+                    .expect("MappingBuilder always produces a mapping");
+                mapping.set(first_key, &empty_mapping);
+                if let Some(nested) = mapping.get_mapping(first_key) {
+                    set_path_on_mapping(&nested, &segments[1..], value);
+                }
+            }
+        }
+        PathSegment::Index(idx) => {
+            if let Some(nested) = mapping.get_sequence(first_key) {
+                set_path_on_sequence(&nested, &segments[1..], value);
+            } else {
+                let empty_seq = crate::SequenceBuilder::new()
+                    .build_document()
+                    .as_sequence()
+                    .expect("SequenceBuilder always produces a sequence");
+                mapping.set(first_key, &empty_seq);
+                if let Some(nested) = mapping.get_sequence(first_key) {
+                    set_path_on_sequence(&nested, &segments[1..], value);
+                }
+            }
+        }
+    }
+}
 
-        // Retrieve and recurse into the newly created mapping
-        if let Some(nested) = mapping.get_mapping(first_key) {
-            set_path_on_mapping(&nested, &segments[1..], value);
+fn set_path_on_sequence<V: crate::AsYaml>(seq: &crate::Sequence, segments: &[PathSegment], value: V) {
+    if segments.is_empty() {
+        return;
+    }
+
+    let index = match &segments[0] {
+        PathSegment::Index(idx) => *idx,
+        PathSegment::Key(_) => return,
+    };
+
+    if segments.len() == 1 {
+        seq.set(index, value);
+        return;
+    }
+
+    let next_segment = &segments[1];
+    match next_segment {
+        PathSegment::Key(_) => {
+            if let Some(item) = seq.get(index) {
+                if let Some(nested) = item.as_mapping() {
+                    set_path_on_mapping(&nested, &segments[1..], value);
+                } else {
+                    let empty_mapping = crate::MappingBuilder::new()
+                        .build_document()
+                        .as_mapping()
+                        .expect("MappingBuilder always produces a mapping");
+                    seq.set(index, &empty_mapping);
+                    if let Some(item) = seq.get(index) {
+                        if let Some(nested) = item.as_mapping() {
+                            set_path_on_mapping(&nested, &segments[1..], value);
+                        }
+                    }
+                }
+            } else {
+                // Fill with nulls up to index
+                while seq.len() <= index {
+                    seq.push(crate::scalar::ScalarValue::Null);
+                }
+                let empty_mapping = crate::MappingBuilder::new()
+                    .build_document()
+                    .as_mapping()
+                    .expect("MappingBuilder always produces a mapping");
+                seq.set(index, &empty_mapping);
+                if let Some(item) = seq.get(index) {
+                    if let Some(nested) = item.as_mapping() {
+                        set_path_on_mapping(&nested, &segments[1..], value);
+                    }
+                }
+            }
+        }
+        PathSegment::Index(next_idx) => {
+            if let Some(item) = seq.get(index) {
+                if let Some(nested) = item.as_sequence() {
+                    set_path_on_sequence(&nested, &segments[1..], value);
+                } else {
+                    let empty_seq = crate::SequenceBuilder::new()
+                        .build_document()
+                        .as_sequence()
+                        .expect("SequenceBuilder always produces a sequence");
+                    seq.set(index, &empty_seq);
+                    if let Some(item) = seq.get(index) {
+                        if let Some(nested) = item.as_sequence() {
+                            set_path_on_sequence(&nested, &segments[1..], value);
+                        }
+                    }
+                }
+            } else {
+                // Fill with nulls up to index
+                while seq.len() <= index {
+                    seq.push(crate::scalar::ScalarValue::Null);
+                }
+                let empty_seq = crate::SequenceBuilder::new()
+                    .build_document()
+                    .as_sequence()
+                    .expect("SequenceBuilder always produces a sequence");
+                seq.set(index, &empty_seq);
+                if let Some(item) = seq.get(index) {
+                    if let Some(nested) = item.as_sequence() {
+                        set_path_on_sequence(&nested, &segments[1..], value);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes an issue where `Sequence::push` either hardcodes indentation to 2 spaces or fails to find the correct indentation for deeply nested sequences. This previously caused document corruption when the new node was inserted into the syntax tree because the indentation mismatch broke the YAML hierarchy.