### PR TITLE
Return Result from mutation methods

### DIFF
--- a/examples/directive_example.rs
+++ b/examples/directive_example.rs
@@ -41,9 +41,9 @@ version: 1.0.0
 
     // Create a document
     let doc = Document::new_mapping();
-    doc.set("application", "yaml-edit");
-    doc.set("version", "0.1.0");
-    doc.set("author", "Jelmer Vernooĳ");
+    doc.set("application", "yaml-edit").unwrap();
+    doc.set("version", "0.1.0").unwrap();
+    doc.set("author", "Jelmer Vernooĳ").unwrap();
 
     yaml.push_document(doc);
 

--- a/examples/edit_example.rs
+++ b/examples/edit_example.rs
@@ -36,8 +36,8 @@ features:
 
     // Edit the document
     if let Some(doc) = yaml.document() {
-        doc.set("name", "my-awesome-project");
-        doc.set("version", "2.1.0");
+        doc.set("name", "my-awesome-project").unwrap();
+        doc.set("version", "2.1.0").unwrap();
 
         println!("After editing:");
         println!("{}", doc);

--- a/src/as_yaml.rs
+++ b/src/as_yaml.rs
@@ -830,13 +830,9 @@ impl AsYaml for &str {
         use crate::lex::SyntaxKind;
         use crate::scalar::ScalarValue;
 
-        // In flow context (JSON), always use double-quoted strings for compatibility
-        // In block context (YAML), use standard quoting rules
-        let scalar = if flow_context {
-            ScalarValue::double_quoted(*self)
-        } else {
-            ScalarValue::string(*self)
-        };
+        // Use flow-context-aware quoting: in flow context, strings containing
+        // flow indicators ([, ], {, }, ,) will be quoted; plain strings stay unquoted.
+        let scalar = ScalarValue::string_in_context(*self, flow_context);
 
         let yaml_text = scalar.to_yaml_string();
         // Both quoted and unquoted strings use STRING token kind;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -923,7 +923,7 @@ Reference:
 
         // Set the sequence back
         if let Some(seq) = seq_doc.as_sequence() {
-            mapping.set("Reference", seq);
+            mapping.set("Reference", seq).unwrap();
         }
 
         let result = doc.to_string();

--- a/src/nodes/directive.rs
+++ b/src/nodes/directive.rs
@@ -145,7 +145,7 @@ mod tests {
         yaml.add_directive("%YAML 1.2");
 
         let doc = Document::new_mapping();
-        doc.set("name", "test");
+        doc.set("name", "test").unwrap();
         yaml.push_document(doc);
 
         let output = yaml.to_string();

--- a/src/nodes/document.rs
+++ b/src/nodes/document.rs
@@ -153,20 +153,25 @@ impl Document {
     }
 
     /// Set a scalar value in the document (assumes document is a mapping)
-    pub fn set(&self, key: impl crate::AsYaml, value: impl crate::AsYaml) {
+    pub fn set(
+        &self,
+        key: impl crate::AsYaml,
+        value: impl crate::AsYaml,
+    ) -> Result<(), crate::error::YamlError> {
         if let Some(mapping) = self.as_mapping() {
-            mapping.set(key, value);
+            mapping.set(key, value)?;
             // Changes are applied directly via splice_children, no need to replace
         } else {
             // If document is not a mapping, create one and add it to the document
             let mapping = Mapping::new();
-            mapping.set(key, value);
+            mapping.set(key, value)?;
 
             // Add the mapping node directly to the document
             let child_count = self.0.children_with_tokens().count();
             self.0
                 .splice_children(child_count..child_count, vec![mapping.0.into()]);
         }
+        Ok(())
     }
 
     /// Set a key-value pair with field ordering support.
@@ -179,23 +184,25 @@ impl Document {
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
         field_order: I,
-    ) where
+    ) -> Result<(), crate::error::YamlError>
+    where
         I: IntoIterator<Item = K>,
         K: crate::AsYaml,
     {
         // Collect so we can pass to both branches if needed.
         let field_order: Vec<K> = field_order.into_iter().collect();
         if let Some(mapping) = self.as_mapping() {
-            mapping.set_with_field_order(key, value, field_order);
+            mapping.set_with_field_order(key, value, field_order)?;
             // Changes are applied directly via splice_children, no need to replace
         } else {
             // If document is not a mapping, create one and splice it in.
             let mapping = Mapping::new();
-            mapping.set_with_field_order(key, value, field_order);
+            mapping.set_with_field_order(key, value, field_order)?;
             let child_count = self.0.children_with_tokens().count();
             self.0
                 .splice_children(child_count..child_count, vec![mapping.0.into()]);
         }
+        Ok(())
     }
 
     /// Remove a key from the document (assumes document is a mapping).
@@ -308,11 +315,11 @@ impl Document {
         after_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(mapping) = self.as_mapping() {
             mapping.insert_after(after_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -329,11 +336,11 @@ impl Document {
         after_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(mapping) = self.as_mapping() {
             mapping.move_after(after_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -350,11 +357,11 @@ impl Document {
         before_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(mapping) = self.as_mapping() {
             mapping.insert_before(before_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -371,11 +378,11 @@ impl Document {
         before_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(mapping) = self.as_mapping() {
             mapping.move_before(before_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -400,20 +407,21 @@ impl Document {
         index: usize,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) {
+    ) -> Result<(), crate::error::YamlError> {
         // Delegate to Mapping::insert_at_index if we have a mapping
         if let Some(mapping) = self.as_mapping() {
-            mapping.insert_at_index(index, key, value);
-            return;
+            mapping.insert_at_index(index, key, value)?;
+            return Ok(());
         }
 
         // No mapping exists yet: create one and replace document contents
         let mapping = Mapping::new();
-        mapping.insert_at_index_preserving(index, key, value);
+        mapping.insert_at_index_preserving(index, key, value)?;
         let new_doc = Self::from_mapping(mapping);
         let new_children: Vec<_> = new_doc.0.children_with_tokens().collect();
         let child_count = self.0.children_with_tokens().count();
         self.0.splice_children(0..child_count, new_children);
+        Ok(())
     }
 
     /// Get the scalar value for `key` as a decoded `String`.
@@ -810,7 +818,7 @@ Author: Someone
         let doc = parsed.document().expect("Should have a document");
 
         // Update Version - should stay in middle
-        doc.set("Version", 2.0);
+        doc.set("Version", 2.0).unwrap();
 
         let output = doc.to_string();
         let expected = r#"Name: original
@@ -954,7 +962,7 @@ active: true
 
         // Test Document.insert_after with sequence
         let doc1 = Document::new();
-        doc1.set("name", "project");
+        doc1.set("name", "project").unwrap();
         let features = SequenceBuilder::new()
             .item("auth")
             .item("api")
@@ -962,7 +970,7 @@ active: true
             .build_document()
             .as_sequence()
             .unwrap();
-        let success = doc1.insert_after("name", "features", features);
+        let success = doc1.insert_after("name", "features", features).unwrap();
         assert!(success);
         let output1 = doc1.to_string();
         assert_eq!(
@@ -972,15 +980,15 @@ active: true
 
         // Test Document.insert_before with mapping
         let doc2 = Document::new();
-        doc2.set("name", "project");
-        doc2.set("version", "1.0.0");
+        doc2.set("name", "project").unwrap();
+        doc2.set("version", "1.0.0").unwrap();
         let database = MappingBuilder::new()
             .pair("host", "localhost")
             .pair("port", 5432)
             .build_document()
             .as_mapping()
             .unwrap();
-        let success = doc2.insert_before("version", "database", database);
+        let success = doc2.insert_before("version", "database", database).unwrap();
         assert!(success);
         let output2 = doc2.to_string();
         assert_eq!(
@@ -990,7 +998,7 @@ active: true
 
         // Test Document.insert_at_index with set
         let doc3 = Document::new();
-        doc3.set("name", "project");
+        doc3.set("name", "project").unwrap();
         // TODO: migrate away from YamlValue once !!set has a non-YamlValue AsYaml impl
         #[allow(clippy::disallowed_types)]
         let tag_set = {
@@ -1000,7 +1008,7 @@ active: true
             tags.insert("database".to_string());
             YamlValue::from_set(tags)
         };
-        doc3.insert_at_index(1, "tags", tag_set);
+        doc3.insert_at_index(1, "tags", tag_set).unwrap();
         let output3 = doc3.to_string();
         assert_eq!(
             output3,
@@ -1029,7 +1037,8 @@ active: true
 
         // Check and modify fields
         assert!(!doc.contains_key("Repository"));
-        doc.set("Repository", "https://github.com/user/repo.git");
+        doc.set("Repository", "https://github.com/user/repo.git")
+            .unwrap();
         assert!(doc.contains_key("Repository"));
 
         // Test get_string
@@ -1058,10 +1067,13 @@ active: true
         let doc = Document::new();
 
         // Add fields in random order
-        doc.set("Repository-Browse", "https://github.com/user/repo");
-        doc.set("Name", "MyProject");
-        doc.set("Bug-Database", "https://github.com/user/repo/issues");
-        doc.set("Repository", "https://github.com/user/repo.git");
+        doc.set("Repository-Browse", "https://github.com/user/repo")
+            .unwrap();
+        doc.set("Name", "MyProject").unwrap();
+        doc.set("Bug-Database", "https://github.com/user/repo/issues")
+            .unwrap();
+        doc.set("Repository", "https://github.com/user/repo.git")
+            .unwrap();
 
         // Reorder fields
         doc.reorder_fields(["Name", "Bug-Database", "Repository", "Repository-Browse"]);
@@ -1101,7 +1113,7 @@ active: true
             .build_document()
             .as_sequence()
             .unwrap();
-        doc.set("Repository", &array_value);
+        doc.set("Repository", &array_value).unwrap();
 
         // Test array detection
         assert!(doc.is_sequence("Repository"));
@@ -1119,8 +1131,9 @@ active: true
 
         // Create and save a document
         let doc = Document::new();
-        doc.set("Name", "TestProject");
-        doc.set("Repository", "https://example.com/repo.git");
+        doc.set("Name", "TestProject").unwrap();
+        doc.set("Repository", "https://example.com/repo.git")
+            .unwrap();
 
         doc.to_file(test_path)?;
 
@@ -1335,7 +1348,10 @@ features:
                 "Repository",
                 "https://github.com/example/example.git",
             );
-            assert!(result, "insert_after should return true when key is found");
+            assert!(
+                result.unwrap(),
+                "insert_after should return true when key is found"
+            );
 
             // Check the document output directly
             let output = doc.to_string();
@@ -1356,11 +1372,13 @@ Repository: https://github.com/example/example.git
         let yaml_obj = YamlFile::from_str(yaml).unwrap();
 
         if let Some(doc) = yaml_obj.document() {
-            let result = doc.insert_after(
-                "Bug-Submit",
-                "Repository",
-                "https://github.com/example/example.git",
-            );
+            let result = doc
+                .insert_after(
+                    "Bug-Submit",
+                    "Repository",
+                    "https://github.com/example/example.git",
+                )
+                .unwrap();
             assert!(result, "insert_after should return true when key is found");
 
             let output = doc.to_string();

--- a/src/nodes/document.rs
+++ b/src/nodes/document.rs
@@ -117,20 +117,25 @@ impl Document {
     }
 
     /// Set a scalar value in the document (assumes document is a mapping)
-    pub fn set(&self, key: impl crate::AsYaml, value: impl crate::AsYaml) {
+    pub fn set(
+        &self,
+        key: impl crate::AsYaml,
+        value: impl crate::AsYaml,
+    ) -> Result<(), crate::error::YamlError> {
         if let Some(mapping) = self.as_mapping() {
-            mapping.set(key, value);
+            mapping.set(key, value)?;
             // Changes are applied directly via splice_children, no need to replace
         } else {
             // If document is not a mapping, create one and add it to the document
             let mapping = Mapping::new();
-            mapping.set(key, value);
+            mapping.set(key, value)?;
 
             // Add the mapping node directly to the document
             let child_count = self.0.children_with_tokens().count();
             self.0
                 .splice_children(child_count..child_count, vec![mapping.0.into()]);
         }
+        Ok(())
     }
 
     /// Set a key-value pair with field ordering support.
@@ -143,23 +148,25 @@ impl Document {
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
         field_order: I,
-    ) where
+    ) -> Result<(), crate::error::YamlError>
+    where
         I: IntoIterator<Item = K>,
         K: crate::AsYaml,
     {
         // Collect so we can pass to both branches if needed.
         let field_order: Vec<K> = field_order.into_iter().collect();
         if let Some(mapping) = self.as_mapping() {
-            mapping.set_with_field_order(key, value, field_order);
+            mapping.set_with_field_order(key, value, field_order)?;
             // Changes are applied directly via splice_children, no need to replace
         } else {
             // If document is not a mapping, create one and splice it in.
             let mapping = Mapping::new();
-            mapping.set_with_field_order(key, value, field_order);
+            mapping.set_with_field_order(key, value, field_order)?;
             let child_count = self.0.children_with_tokens().count();
             self.0
                 .splice_children(child_count..child_count, vec![mapping.0.into()]);
         }
+        Ok(())
     }
 
     /// Remove a key from the document (assumes document is a mapping).
@@ -272,11 +279,11 @@ impl Document {
         after_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(mapping) = self.as_mapping() {
             mapping.insert_after(after_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -293,11 +300,11 @@ impl Document {
         after_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(mapping) = self.as_mapping() {
             mapping.move_after(after_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -314,11 +321,11 @@ impl Document {
         before_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(mapping) = self.as_mapping() {
             mapping.insert_before(before_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -335,11 +342,11 @@ impl Document {
         before_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(mapping) = self.as_mapping() {
             mapping.move_before(before_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -364,20 +371,21 @@ impl Document {
         index: usize,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) {
+    ) -> Result<(), crate::error::YamlError> {
         // Delegate to Mapping::insert_at_index if we have a mapping
         if let Some(mapping) = self.as_mapping() {
-            mapping.insert_at_index(index, key, value);
-            return;
+            mapping.insert_at_index(index, key, value)?;
+            return Ok(());
         }
 
         // No mapping exists yet: create one and replace document contents
         let mapping = Mapping::new();
-        mapping.insert_at_index_preserving(index, key, value);
+        mapping.insert_at_index_preserving(index, key, value)?;
         let new_doc = Self::from_mapping(mapping);
         let new_children: Vec<_> = new_doc.0.children_with_tokens().collect();
         let child_count = self.0.children_with_tokens().count();
         self.0.splice_children(0..child_count, new_children);
+        Ok(())
     }
 
     /// Get the scalar value for `key` as a decoded `String`.
@@ -774,7 +782,7 @@ Author: Someone
         let doc = parsed.document().expect("Should have a document");
 
         // Update Version - should stay in middle
-        doc.set("Version", 2.0);
+        doc.set("Version", 2.0).unwrap();
 
         let output = doc.to_string();
         let expected = r#"Name: original
@@ -918,7 +926,7 @@ active: true
 
         // Test Document.insert_after with sequence
         let doc1 = Document::new();
-        doc1.set("name", "project");
+        doc1.set("name", "project").unwrap();
         let features = SequenceBuilder::new()
             .item("auth")
             .item("api")
@@ -926,7 +934,7 @@ active: true
             .build_document()
             .as_sequence()
             .unwrap();
-        let success = doc1.insert_after("name", "features", features);
+        let success = doc1.insert_after("name", "features", features).unwrap();
         assert!(success);
         let output1 = doc1.to_string();
         assert_eq!(
@@ -936,15 +944,15 @@ active: true
 
         // Test Document.insert_before with mapping
         let doc2 = Document::new();
-        doc2.set("name", "project");
-        doc2.set("version", "1.0.0");
+        doc2.set("name", "project").unwrap();
+        doc2.set("version", "1.0.0").unwrap();
         let database = MappingBuilder::new()
             .pair("host", "localhost")
             .pair("port", 5432)
             .build_document()
             .as_mapping()
             .unwrap();
-        let success = doc2.insert_before("version", "database", database);
+        let success = doc2.insert_before("version", "database", database).unwrap();
         assert!(success);
         let output2 = doc2.to_string();
         assert_eq!(
@@ -954,7 +962,7 @@ active: true
 
         // Test Document.insert_at_index with set
         let doc3 = Document::new();
-        doc3.set("name", "project");
+        doc3.set("name", "project").unwrap();
         // TODO: migrate away from YamlValue once !!set has a non-YamlValue AsYaml impl
         #[allow(clippy::disallowed_types)]
         let tag_set = {
@@ -964,7 +972,7 @@ active: true
             tags.insert("database".to_string());
             YamlValue::from_set(tags)
         };
-        doc3.insert_at_index(1, "tags", tag_set);
+        doc3.insert_at_index(1, "tags", tag_set).unwrap();
         let output3 = doc3.to_string();
         assert_eq!(
             output3,
@@ -993,7 +1001,8 @@ active: true
 
         // Check and modify fields
         assert!(!doc.contains_key("Repository"));
-        doc.set("Repository", "https://github.com/user/repo.git");
+        doc.set("Repository", "https://github.com/user/repo.git")
+            .unwrap();
         assert!(doc.contains_key("Repository"));
 
         // Test get_string
@@ -1022,10 +1031,13 @@ active: true
         let doc = Document::new();
 
         // Add fields in random order
-        doc.set("Repository-Browse", "https://github.com/user/repo");
-        doc.set("Name", "MyProject");
-        doc.set("Bug-Database", "https://github.com/user/repo/issues");
-        doc.set("Repository", "https://github.com/user/repo.git");
+        doc.set("Repository-Browse", "https://github.com/user/repo")
+            .unwrap();
+        doc.set("Name", "MyProject").unwrap();
+        doc.set("Bug-Database", "https://github.com/user/repo/issues")
+            .unwrap();
+        doc.set("Repository", "https://github.com/user/repo.git")
+            .unwrap();
 
         // Reorder fields
         doc.reorder_fields(["Name", "Bug-Database", "Repository", "Repository-Browse"]);
@@ -1065,7 +1077,7 @@ active: true
             .build_document()
             .as_sequence()
             .unwrap();
-        doc.set("Repository", &array_value);
+        doc.set("Repository", &array_value).unwrap();
 
         // Test array detection
         assert!(doc.is_sequence("Repository"));
@@ -1083,8 +1095,9 @@ active: true
 
         // Create and save a document
         let doc = Document::new();
-        doc.set("Name", "TestProject");
-        doc.set("Repository", "https://example.com/repo.git");
+        doc.set("Name", "TestProject").unwrap();
+        doc.set("Repository", "https://example.com/repo.git")
+            .unwrap();
 
         doc.to_file(test_path)?;
 
@@ -1299,7 +1312,10 @@ features:
                 "Repository",
                 "https://github.com/example/example.git",
             );
-            assert!(result, "insert_after should return true when key is found");
+            assert!(
+                result.unwrap(),
+                "insert_after should return true when key is found"
+            );
 
             // Check the document output directly
             let output = doc.to_string();
@@ -1320,11 +1336,13 @@ Repository: https://github.com/example/example.git
         let yaml_obj = YamlFile::from_str(yaml).unwrap();
 
         if let Some(doc) = yaml_obj.document() {
-            let result = doc.insert_after(
-                "Bug-Submit",
-                "Repository",
-                "https://github.com/example/example.git",
-            );
+            let result = doc
+                .insert_after(
+                    "Bug-Submit",
+                    "Repository",
+                    "https://github.com/example/example.git",
+                )
+                .unwrap();
             assert!(result, "insert_after should return true when key is found");
 
             let output = doc.to_string();

--- a/src/nodes/mapping.rs
+++ b/src/nodes/mapping.rs
@@ -78,7 +78,13 @@ impl MappingEntry {
         value: impl crate::AsYaml,
         flow_context: bool,
         use_explicit_key: bool,
-    ) -> Self {
+    ) -> Result<Self, crate::error::YamlError> {
+        if flow_context && !value.is_inline() {
+            return Err(crate::error::YamlError::InvalidOperation {
+                operation: "new mapping entry".to_string(),
+                reason: "cannot insert block-style content into a flow mapping".to_string(),
+            });
+        }
         let mut builder = GreenNodeBuilder::new();
         builder.start_node(SyntaxKind::MAPPING_ENTRY.into());
 
@@ -135,11 +141,21 @@ impl MappingEntry {
         }
 
         builder.finish_node(); // MAPPING_ENTRY
-        MappingEntry(SyntaxNode::new_root_mut(builder.finish()))
+        Ok(MappingEntry(SyntaxNode::new_root_mut(builder.finish())))
     }
 
     /// Replace the value of this entry in place, preserving the key and surrounding whitespace.
-    pub fn set_value(&self, new_value: impl crate::AsYaml, flow_context: bool) {
+    pub fn set_value(
+        &self,
+        new_value: impl crate::AsYaml,
+        flow_context: bool,
+    ) -> Result<(), crate::error::YamlError> {
+        if flow_context && !new_value.is_inline() {
+            return Err(crate::error::YamlError::InvalidOperation {
+                operation: "set value".to_string(),
+                reason: "cannot insert block-style content into a flow mapping".to_string(),
+            });
+        }
         // Build new VALUE node, preserving any inline comment from the old value
         let mut value_builder = GreenNodeBuilder::new();
         value_builder.start_node(SyntaxKind::VALUE.into());
@@ -184,7 +200,7 @@ impl MappingEntry {
                 if node.kind() == SyntaxKind::VALUE {
                     self.0
                         .splice_children(i..i + 1, vec![new_value_node.into()]);
-                    return;
+                    return Ok(());
                 }
             }
         }
@@ -226,6 +242,7 @@ impl MappingEntry {
         let new_children: Vec<_> = new_entry.children_with_tokens().collect();
         let child_count = self.0.children_with_tokens().count();
         self.0.splice_children(0..child_count, new_children);
+        Ok(())
     }
 
     /// Detach this entry from its parent mapping, effectively removing it.
@@ -675,8 +692,12 @@ impl Mapping {
     /// which return `bool` to indicate whether the anchor key was found.
     ///
     /// Mutates in place despite `&self` (see crate docs on interior mutability).
-    pub fn set(&self, key: impl crate::AsYaml, value: impl crate::AsYaml) {
-        self.set_as_yaml(key, value);
+    pub fn set(
+        &self,
+        key: impl crate::AsYaml,
+        value: impl crate::AsYaml,
+    ) -> Result<(), crate::error::YamlError> {
+        self.set_as_yaml(key, value)
     }
 
     /// Detect if this mapping uses explicit key indicators (?)
@@ -698,7 +719,11 @@ impl Mapping {
     }
 
     /// Internal unified method to set any YAML value type
-    fn set_as_yaml<K: crate::AsYaml, V: crate::AsYaml>(&self, key: K, value: V) {
+    fn set_as_yaml<K: crate::AsYaml, V: crate::AsYaml>(
+        &self,
+        key: K,
+        value: V,
+    ) -> Result<(), crate::error::YamlError> {
         // Detect if this mapping is in flow style (JSON format)
         let flow_context = self.is_flow_style();
 
@@ -714,10 +739,10 @@ impl Mapping {
                         if let Some(entry_key_node) = entry.key() {
                             if key_content_matches(&entry_key_node, &key) {
                                 // Found it! Update the value in place
-                                entry.set_value(value, flow_context);
+                                entry.set_value(value, flow_context)?;
 
                                 self.0.splice_children(i..i + 1, vec![entry.0.into()]);
-                                return;
+                                return Ok(());
                             }
                         }
                     }
@@ -726,8 +751,9 @@ impl Mapping {
         }
 
         // Entry doesn't exist, create a new one
-        let new_entry = MappingEntry::new(key, value, flow_context, use_explicit_keys);
+        let new_entry = MappingEntry::new(key, value, flow_context, use_explicit_keys)?;
         self.insert_entry_cst(&new_entry.0);
+        Ok(())
     }
 
     /// Internal method to insert a new entry at the end (does not check for duplicates)
@@ -992,7 +1018,8 @@ impl Mapping {
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
         field_order: I,
-    ) where
+    ) -> Result<(), crate::error::YamlError>
+    where
         I: IntoIterator<Item = K>,
         K: crate::AsYaml,
     {
@@ -1007,8 +1034,8 @@ impl Mapping {
                     if let Some(key_node) = node.children().find(|n| n.kind() == SyntaxKind::KEY) {
                         if key_content_matches(&key_node, &key) {
                             // Key exists, update its value using unified method
-                            self.set_as_yaml(&key, &value);
-                            return;
+                            self.set_as_yaml(&key, &value)?;
+                            return Ok(());
                         }
                     }
                 }
@@ -1077,7 +1104,7 @@ impl Mapping {
             // Build the new entry with proper newline ownership
             let flow_context = self.is_flow_style();
             let use_explicit_keys = self.uses_explicit_keys();
-            let new_entry = MappingEntry::new(&key, &value, flow_context, use_explicit_keys).0;
+            let new_entry = MappingEntry::new(&key, &value, flow_context, use_explicit_keys)?.0;
 
             // Insert after the target entry, ensuring it has a trailing newline
             if let Some(after_node) = insert_after_node {
@@ -1151,12 +1178,13 @@ impl Mapping {
                 self.0.splice_children(idx..idx, vec![new_entry.into()]);
             } else {
                 // No existing ordered keys, just append using CST
-                self.set_as_yaml(&key, &value);
+                self.set_as_yaml(&key, &value)?;
             }
         } else {
             // Key is not in field order, append at the end using CST
-            self.set_as_yaml(&key, &value);
+            self.set_as_yaml(&key, &value)?;
         }
+        Ok(())
     }
 
     /// Detect the indentation level (in spaces) used by entries in this mapping.
@@ -1190,7 +1218,7 @@ impl Mapping {
         after_key: impl crate::AsYaml,
         new_key: impl crate::AsYaml,
         new_value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         self.move_after_impl(after_key, new_key, new_value)
     }
 
@@ -1200,7 +1228,7 @@ impl Mapping {
         after_key: impl crate::AsYaml,
         new_key: impl crate::AsYaml,
         new_value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         let children: Vec<_> = self.0.children_with_tokens().collect();
         let mut insert_position = None;
         let mut found_key = false;
@@ -1440,16 +1468,16 @@ impl Mapping {
             }
 
             // Create the MAPPING_ENTRY node
-            let (entry, _has_trailing_newline) = self.create_mapping_entry(&new_key, &new_value);
+            let (entry, _has_trailing_newline) = self.create_mapping_entry(&new_key, &new_value)?;
 
             // Add the new entry (which already has its own trailing newline)
             new_elements.push(entry.into());
 
             // Splice in the new elements
             self.0.splice_children(pos..pos, new_elements);
-            true
+            Ok(true)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -1468,7 +1496,7 @@ impl Mapping {
         before_key: impl crate::AsYaml,
         new_key: impl crate::AsYaml,
         new_value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         self.move_before_impl(before_key, new_key, new_value)
     }
 
@@ -1478,7 +1506,7 @@ impl Mapping {
         before_key: impl crate::AsYaml,
         new_key: impl crate::AsYaml,
         new_value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         let children: Vec<_> = self.0.children_with_tokens().collect();
         let mut insert_position = None;
 
@@ -1533,12 +1561,12 @@ impl Mapping {
                                 let j = i + 1 + offset;
                                 self.0
                                     .splice_children(j..j + 1, vec![new_value_node.into()]);
-                                return true;
+                                return Ok(true);
                             }
                         }
                     }
                     // If no VALUE node found, something's wrong with the structure
-                    return false;
+                    return Ok(false);
                 }
             }
             if !removed_existing {
@@ -1604,7 +1632,7 @@ impl Mapping {
             let mut new_elements = Vec::new();
 
             // Create the MAPPING_ENTRY node
-            let (entry, _has_trailing_newline) = self.create_mapping_entry(&new_key, &new_value);
+            let (entry, _has_trailing_newline) = self.create_mapping_entry(&new_key, &new_value)?;
             new_elements.push(entry.into());
 
             // Note: create_mapping_entry already adds a trailing newline to the MAPPING_ENTRY
@@ -1612,9 +1640,9 @@ impl Mapping {
 
             // Splice in the new elements
             self.0.splice_children(pos..pos, new_elements);
-            true
+            Ok(true)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -1630,9 +1658,9 @@ impl Mapping {
         index: usize,
         new_key: impl crate::AsYaml,
         new_value: impl crate::AsYaml,
-    ) {
+    ) -> Result<(), crate::error::YamlError> {
         // Create the new entry using create_mapping_entry
-        let (new_entry, _has_trailing_newline) = self.create_mapping_entry(new_key, new_value);
+        let (new_entry, _has_trailing_newline) = self.create_mapping_entry(new_key, new_value)?;
 
         // Check if key already exists in newly created entry for update detection
         if let Some(created_entry) = MappingEntry::cast(new_entry.clone()) {
@@ -1661,7 +1689,7 @@ impl Mapping {
                         // Just replace the old entry node with the new one
                         self.0.splice_children(i..i + 1, vec![new_entry.into()]);
 
-                        return;
+                        return Ok(());
                     }
                 }
             }
@@ -1727,6 +1755,7 @@ impl Mapping {
 
         // Insert at the calculated position
         self.0.splice_children(insert_pos..insert_pos, new_elements);
+        Ok(())
     }
 
     /// Remove a key-value pair, returning the removed entry.
@@ -1937,7 +1966,14 @@ impl Mapping {
         &self,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> (SyntaxNode, bool) {
+    ) -> Result<(SyntaxNode, bool), crate::error::YamlError> {
+        let flow_context = self.is_flow_style();
+        if flow_context && !value.is_inline() {
+            return Err(crate::error::YamlError::InvalidOperation {
+                operation: "create mapping entry".to_string(),
+                reason: "cannot insert block-style content into a flow mapping".to_string(),
+            });
+        }
         let mut builder = GreenNodeBuilder::new();
         builder.start_node(SyntaxKind::MAPPING_ENTRY.into());
 
@@ -1972,10 +2008,10 @@ impl Mapping {
         };
 
         builder.finish_node(); // MAPPING_ENTRY
-        (
+        Ok((
             SyntaxNode::new_root_mut(builder.finish()),
             added_newline || value_ends_with_newline,
-        )
+        ))
     }
 
     /// Insert a key-value pair immediately after an existing key.
@@ -1994,11 +2030,11 @@ impl Mapping {
         after_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         // Check if the new key already exists - if so, just update it
         if self.find_entry_by_key(&key).is_some() {
-            self.set_as_yaml(&key, &value);
-            return true;
+            self.set_as_yaml(&key, &value)?;
+            return Ok(true);
         }
 
         // Key doesn't exist yet — delegate to move_after, which already contains
@@ -2024,13 +2060,13 @@ impl Mapping {
         before_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         // Key exists → update in-place (don't move).
         if self.find_entry_by_key(&key).is_some() {
-            self.set_as_yaml(&key, &value);
+            self.set_as_yaml(&key, &value)?;
             // Only return true if before_key also exists (contract: false when
             // reference key is not found).
-            return self.find_entry_by_key(&before_key).is_some();
+            return Ok(self.find_entry_by_key(&before_key).is_some());
         }
 
         // Key doesn't exist yet — delegate to move_before, which already contains
@@ -2044,25 +2080,23 @@ impl Mapping {
     /// If `key` already exists in the mapping, its value is updated in-place and
     /// it remains at its current position (the `index` argument is ignored).
     /// If `index` is out of bounds, the entry is appended at the end.
-    /// This method always succeeds; it never returns an error.
-    ///
     /// Mutates in place despite `&self` (see crate docs on interior mutability).
     pub fn insert_at_index(
         &self,
         index: usize,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) {
+    ) -> Result<(), crate::error::YamlError> {
         // Check if the key already exists - if so, just update it
         if self.find_entry_by_key(&key).is_some() {
-            self.set_as_yaml(&key, &value);
-            return;
+            self.set_as_yaml(&key, &value)?;
+            return Ok(());
         }
 
         // Create the new mapping entry
         let flow_context = self.is_flow_style();
         let use_explicit_keys = self.uses_explicit_keys();
-        let new_entry = MappingEntry::new(&key, &value, flow_context, use_explicit_keys);
+        let new_entry = MappingEntry::new(&key, &value, flow_context, use_explicit_keys)?;
 
         // Count existing entries to determine actual insertion position
         let entry_count = self.entries().count();
@@ -2127,6 +2161,7 @@ impl Mapping {
 
         // Insert at the calculated position
         self.0.splice_children(insert_pos..insert_pos, new_elements);
+        Ok(())
     }
 
     /// Get the byte offset range of this mapping in the source text.
@@ -2222,7 +2257,7 @@ mod tests {
 
         // Get the document and set on it
         let doc = parsed.document().expect("Should have a document");
-        doc.set("new_key", "new_value");
+        doc.set("new_key", "new_value").unwrap();
 
         let output = doc.to_string();
 
@@ -2262,7 +2297,7 @@ new_key: new_value"#;
 
         // Get document and add a new key
         let doc = parsed.document().expect("Should have a document");
-        doc.set("key2", "value2");
+        doc.set("key2", "value2").unwrap();
 
         let output = doc.to_string();
 
@@ -2281,7 +2316,7 @@ Repository: https://github.com/example/repo.git
         let doc = parsed.document().expect("Should have a document");
 
         // Update Contact - it should stay in position 2, not move to the end
-        doc.set("Contact", "updated_contact");
+        doc.set("Contact", "updated_contact").unwrap();
 
         let output = doc.to_string();
         let expected = r#"Name: original_name
@@ -2303,9 +2338,11 @@ Repository: https://github.com/jdonaldson/rtsne.git
 
         if let Some(mapping) = doc.as_mapping() {
             // Update Contact - should stay in position 2
-            mapping.set("Contact", "New Contact <new@example.com>");
+            mapping
+                .set("Contact", "New Contact <new@example.com>")
+                .unwrap();
             // Update Archive - should stay in position 3
-            mapping.set("Archive", "PyPI");
+            mapping.set("Archive", "PyPI").unwrap();
         }
 
         let output = doc.to_string();
@@ -2327,7 +2364,7 @@ fourth: 4"#;
         let doc = parsed.document().expect("Should have a document");
 
         // Insert after "second"
-        let success = doc.insert_after("second", "third", 3);
+        let success = doc.insert_after("second", "third", 3).unwrap();
         assert!(
             success,
             "insert_after should succeed when reference key exists"
@@ -2343,14 +2380,16 @@ fourth: 4"#;
         assert_eq!(output.trim(), expected);
 
         // Test inserting after non-existent key
-        let failed = doc.insert_after("nonexistent", "new_key", "new_value");
+        let failed = doc
+            .insert_after("nonexistent", "new_key", "new_value")
+            .unwrap();
         assert!(
             !failed,
             "insert_after should fail when reference key doesn't exist"
         );
 
         // Test updating existing key through insert_after
-        let updated = doc.insert_after("first", "second", "2_updated");
+        let updated = doc.insert_after("first", "second", "2_updated").unwrap();
         assert!(updated, "insert_after should update existing key");
         let updated_output = doc.to_string();
         let expected_updated = r#"first: 1
@@ -2369,7 +2408,7 @@ fourth: 4"#;
         let doc = parsed.document().expect("Should have a document");
 
         // Insert before "third"
-        let success = doc.insert_before("third", "second", 2);
+        let success = doc.insert_before("third", "second", 2).unwrap();
         assert!(
             success,
             "insert_before should succeed when reference key exists"
@@ -2385,14 +2424,16 @@ fourth: 4"#;
         assert_eq!(output.trim(), expected);
 
         // Test inserting before non-existent key
-        let failed = doc.insert_before("nonexistent", "new_key", "new_value");
+        let failed = doc
+            .insert_before("nonexistent", "new_key", "new_value")
+            .unwrap();
         assert!(
             !failed,
             "insert_before should fail when reference key doesn't exist"
         );
 
         // Test updating existing key through insert_before
-        let updated = doc.insert_before("fourth", "third", "3_updated");
+        let updated = doc.insert_before("fourth", "third", "3_updated").unwrap();
         assert!(updated, "insert_before should update existing key");
         let output = doc.to_string();
         let expected_updated = r#"first: 1
@@ -2410,7 +2451,7 @@ third: 3"#;
         let doc = parsed.document().expect("Should have a document");
 
         // Insert at index 1 (between first and third)
-        doc.insert_at_index(1, "second", 2);
+        doc.insert_at_index(1, "second", 2).unwrap();
 
         let output = doc.to_string();
 
@@ -2421,7 +2462,7 @@ third: 3"#;
         assert_eq!(output.trim(), expected);
 
         // Insert at index 0 (beginning)
-        doc.insert_at_index(0, "zero", 0);
+        doc.insert_at_index(0, "zero", 0).unwrap();
         let output2 = doc.to_string();
         let expected2 = r#"zero: 0
 first: 1
@@ -2430,7 +2471,7 @@ third: 3"#;
         assert_eq!(output2.trim(), expected2);
 
         // Insert at out-of-bounds index (should append at end)
-        doc.insert_at_index(100, "last", "999");
+        doc.insert_at_index(100, "last", "999").unwrap();
         let output3 = doc.to_string();
         let expected3 = r#"zero: 0
 first: 1
@@ -2440,7 +2481,7 @@ last: '999'"#;
         assert_eq!(output3.trim(), expected3);
 
         // Test updating existing key through insert_at_index
-        doc.insert_at_index(2, "first", "1_updated");
+        doc.insert_at_index(2, "first", "1_updated").unwrap();
         let final_output = doc.to_string();
         let expected_final = r#"zero: 0
 first: 1_updated
@@ -2457,9 +2498,11 @@ last: '999'"#;
         let doc = parsed.document().expect("Should have a document");
 
         // Test with special characters that need escaping
-        doc.insert_after("key1", "special:key", "value:with:colons");
-        doc.insert_before("key1", "key with spaces", "value with spaces");
-        doc.insert_at_index(1, "key@symbol", "value#hash");
+        doc.insert_after("key1", "special:key", "value:with:colons")
+            .unwrap();
+        doc.insert_before("key1", "key with spaces", "value with spaces")
+            .unwrap();
+        doc.insert_at_index(1, "key@symbol", "value#hash").unwrap();
 
         // Verify all keys are present
         assert!(doc.contains_key("special:key"));
@@ -2479,8 +2522,9 @@ last: '999'"#;
         let doc = parsed.document().expect("Should have a document");
 
         // Test with empty values
-        doc.insert_after("key1", "empty", "");
-        doc.insert_before("key1", "null_key", ScalarValue::null());
+        doc.insert_after("key1", "empty", "").unwrap();
+        doc.insert_before("key1", "null_key", ScalarValue::null())
+            .unwrap();
 
         assert!(doc.contains_key("empty"));
         assert!(doc.contains_key("null_key"));
@@ -2659,7 +2703,7 @@ last: '999'"#;
         let doc = yaml.document().unwrap();
         let mapping = doc.as_mapping().unwrap();
 
-        mapping.set("age", 30);
+        mapping.set("age", 30).unwrap();
 
         let keys: Vec<String> = mapping.keys().map(|k| k.to_string()).collect();
         assert_eq!(keys, vec!["name", "age"]);
@@ -2672,7 +2716,7 @@ last: '999'"#;
         let doc = yaml.document().unwrap();
         let mapping = doc.as_mapping().unwrap();
 
-        mapping.set("age", 31);
+        mapping.set("age", 31).unwrap();
 
         assert_eq!(mapping.get("age").and_then(|v| v.to_i64()), Some(31));
         let keys: Vec<String> = mapping.keys().map(|k| k.to_string()).collect();
@@ -2792,9 +2836,9 @@ features:
         if let Some(doc) = yaml.document() {
             if let Some(mapping) = doc.as_mapping() {
                 // Add new fields
-                mapping.set("license", "MIT");
-                mapping.set("published", true);
-                mapping.set("downloads", 1000);
+                mapping.set("license", "MIT").unwrap();
+                mapping.set("published", true).unwrap();
+                mapping.set("downloads", 1000).unwrap();
 
                 // Remove a field
                 mapping.remove("author");
@@ -2803,7 +2847,7 @@ features:
                 mapping.rename_key("version", "app_version");
 
                 // Update existing field
-                mapping.set("year", 2024);
+                mapping.set("year", 2024).unwrap();
             }
         }
 
@@ -2945,9 +2989,9 @@ downloads: 1000
         let doc = yaml.document().unwrap();
         let mapping = doc.as_mapping().unwrap();
 
-        mapping.set("number", 123);
-        mapping.set("bool", false);
-        mapping.set("text", "hello");
+        mapping.set("number", 123).unwrap();
+        mapping.set("bool", false).unwrap();
+        mapping.set("text", "hello").unwrap();
 
         assert_eq!(mapping.get("number").and_then(|v| v.to_i64()), Some(123));
         assert_eq!(mapping.get("bool").and_then(|v| v.to_bool()), Some(false));
@@ -2974,7 +3018,7 @@ downloads: 1000
         assert!(!mapping.rename_key("old", "new"));
 
         // Can still add to empty mapping
-        mapping.set("first", "value");
+        mapping.set("first", "value").unwrap();
         assert!(!mapping.is_empty());
         assert_eq!(
             mapping.get("first").map(|v| v.to_string()),
@@ -3058,10 +3102,10 @@ downloads: 1000
 
         assert_eq!(mapping.len(), 1);
 
-        mapping.set("age", 30);
+        mapping.set("age", 30).unwrap();
         assert_eq!(mapping.len(), 2);
 
-        mapping.set("city", "NYC");
+        mapping.set("city", "NYC").unwrap();
         assert_eq!(mapping.len(), 3);
     }
 
@@ -3307,7 +3351,7 @@ downloads: 1000
         assert_eq!(mapping.len(), 0);
 
         // Add new entries after clearing
-        mapping.set("new_key", "new_value");
+        mapping.set("new_key", "new_value").unwrap();
         assert_eq!(mapping.len(), 1);
         let value = mapping.get("new_key").unwrap();
         assert_eq!(
@@ -3383,7 +3427,7 @@ downloads: 1000
         let mapping = doc.as_mapping().unwrap();
 
         // Modify a value
-        mapping.set("key1", "new_value");
+        mapping.set("key1", "new_value").unwrap();
 
         // Should still end with newline
         let output = yaml.to_string();

--- a/src/nodes/mapping.rs
+++ b/src/nodes/mapping.rs
@@ -2976,10 +2976,9 @@ downloads: 1000
         // Can still add to empty mapping
         mapping.set("first", "value");
         assert!(!mapping.is_empty());
-        // In flow-style (JSON) context, strings are quoted
         assert_eq!(
             mapping.get("first").map(|v| v.to_string()),
-            Some("\"value\"".to_string())
+            Some("value".to_string())
         );
     }
 

--- a/src/nodes/sequence.rs
+++ b/src/nodes/sequence.rs
@@ -114,8 +114,59 @@ impl Sequence {
 
     /// Add an item to the end of the sequence.
     ///
+    /// Returns an error if this is a flow-style sequence (`[...]`) and the
+    /// value is not inline (e.g. a block mapping or block sequence), since
+    /// block content cannot appear inside a flow collection.
+    ///
     /// Mutates in place despite `&self` (see crate docs on interior mutability).
-    pub fn push(&self, value: impl crate::AsYaml) {
+    pub fn push(&self, value: impl crate::AsYaml) -> Result<(), crate::error::YamlError> {
+        // For flow-style sequences ([...]), insert as flow content before the RIGHT_BRACKET
+        if self.is_flow_style() {
+            if !value.is_inline() {
+                return Err(crate::error::YamlError::InvalidOperation {
+                    operation: "push".to_string(),
+                    reason: "cannot insert block-style content into a flow sequence".to_string(),
+                });
+            }
+            let has_entries = !self.is_empty();
+            for (i, child) in self.0.children_with_tokens().enumerate() {
+                if let Some(t) = child.as_token() {
+                    if t.kind() == SyntaxKind::RIGHT_BRACKET {
+                        let mut new_elements: Vec<
+                            rowan::NodeOrToken<SyntaxNode, rowan::SyntaxToken<crate::Lang>>,
+                        > = Vec::new();
+
+                        // Add ", " separator if there are existing entries
+                        if has_entries {
+                            let mut sep_builder = GreenNodeBuilder::new();
+                            sep_builder.start_node(SyntaxKind::ROOT.into());
+                            sep_builder.token(SyntaxKind::COMMA.into(), ",");
+                            sep_builder.token(SyntaxKind::WHITESPACE.into(), " ");
+                            sep_builder.finish_node();
+                            let sep_node = SyntaxNode::new_root_mut(sep_builder.finish());
+                            for c in sep_node.children_with_tokens() {
+                                if let rowan::NodeOrToken::Token(tok) = c {
+                                    new_elements.push(tok.into());
+                                }
+                            }
+                        }
+
+                        // Build a SEQUENCE_ENTRY containing the value
+                        let mut entry_builder = GreenNodeBuilder::new();
+                        entry_builder.start_node(SyntaxKind::SEQUENCE_ENTRY.into());
+                        value.build_content(&mut entry_builder, 0, true);
+                        entry_builder.finish_node();
+                        let entry_node = SyntaxNode::new_root_mut(entry_builder.finish());
+                        new_elements.push(entry_node.into());
+
+                        self.0.splice_children(i..i, new_elements);
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        // Block-style sequence: detect the indentation
         let indentation = self.detect_indentation();
 
         // Build the INDENT token (separate from the SEQUENCE_ENTRY)
@@ -217,6 +268,7 @@ impl Sequence {
             insert_pos..insert_pos,
             vec![indent_token.into(), new_entry.into()],
         );
+        Ok(())
     }
 
     /// Insert an item at a specific position.
@@ -313,7 +365,8 @@ impl Sequence {
                                     // trailing NEWLINE+INDENT that must be preserved.
                                     let text = n.text().to_string();
                                     if let Some(last_newline_pos) = text.rfind('\n') {
-                                        trailing_text = Some(text[last_newline_pos..].to_string());
+                                        trailing_text =
+                                            Some(text[last_newline_pos..].to_string());
                                     }
 
                                     // Replace the value node with the new value built from AsYaml
@@ -630,7 +683,7 @@ mod tests {
         let seq = doc.as_sequence().expect("expected a sequence");
 
         // Test push
-        seq.push("item3");
+        seq.push("item3").unwrap();
         let values: Vec<_> = seq.values().collect();
         assert_eq!(values.len(), 3);
         assert_eq!(
@@ -724,7 +777,7 @@ mod tests {
         let doc = Document::from_str(original).unwrap();
         let mapping = doc.as_mapping().unwrap();
         let team = mapping.get_sequence("team").unwrap();
-        team.push("Charlie");
+        team.push("Charlie").unwrap();
 
         let expected = r#"team:
   - Alice
@@ -743,8 +796,8 @@ mod tests {
         let doc = Document::from_str(original).unwrap();
         let mapping = doc.as_mapping().unwrap();
         let team = mapping.get_sequence("team").unwrap();
-        team.push("Charlie");
-        team.push("Diana");
+        team.push("Charlie").unwrap();
+        team.push("Diana").unwrap();
 
         let expected = r#"team:
   - Alice
@@ -788,9 +841,9 @@ scores:
         let doc = Document::from_str(original).unwrap();
         let mapping = doc.as_mapping().unwrap();
         let team = mapping.get_sequence("team").unwrap();
-        team.push("Charlie");
+        team.push("Charlie").unwrap();
         let scores = mapping.get_sequence("scores").unwrap();
-        scores.push(92);
+        scores.push(92).unwrap();
         scores.set(0, 100);
 
         let expected = r#"team:
@@ -822,7 +875,7 @@ scores:
         config.set("retries", 5);
 
         let servers = config.get_sequence("servers").unwrap();
-        servers.push("host3");
+        servers.push("host3").unwrap();
         servers.set(0, "primary-host");
 
         let expected = r#"config:
@@ -1182,7 +1235,7 @@ scores:
         let seq = mapping.get_sequence("items").unwrap();
 
         assert_eq!(seq.len(), 2);
-        seq.push("c");
+        seq.push("c").unwrap();
         assert_eq!(seq.len(), 3);
 
         let values: Vec<String> = seq.values().map(|v| v.to_string()).collect();
@@ -1196,9 +1249,9 @@ scores:
         let mapping = doc.as_mapping().unwrap();
         let seq = mapping.get_sequence("items").unwrap();
 
-        seq.push("b");
-        seq.push("c");
-        seq.push("d");
+        seq.push("b").unwrap();
+        seq.push("c").unwrap();
+        seq.push("d").unwrap();
 
         let values: Vec<String> = seq.values().map(|v| v.to_string()).collect();
         assert_eq!(values, vec!["a", "b", "c", "d"]);
@@ -1264,7 +1317,7 @@ scores:
         let seq = mapping.get_sequence("items").unwrap();
 
         assert_eq!(seq.len(), 2);
-        seq.push("c");
+        seq.push("c").unwrap();
         assert_eq!(seq.len(), 3);
 
         let values: Vec<String> = seq.values().map(|v| v.to_string()).collect();
@@ -1368,5 +1421,226 @@ scores:
             doc.to_string(),
             "items:\n  - replaced\n  - name: second\n    value: 2\n"
         );
+    }
+
+    #[test]
+    fn test_sequence_push_empty_flow() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        let doc = Document::from_str("seq: []").unwrap();
+        let seq = doc.get_path("seq").unwrap().as_sequence().unwrap().clone();
+        seq.push("item1").unwrap();
+        assert_eq!(doc.to_string(), "seq: [item1]");
+    }
+
+    #[test]
+    fn test_sequence_push_non_empty_flow() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        let doc = Document::from_str("seq: [a, b]").unwrap();
+        let seq = doc.get_path("seq").unwrap().as_sequence().unwrap().clone();
+        seq.push("c").unwrap();
+        assert_eq!(doc.to_string(), "seq: [a, b, c]");
+    }
+
+    #[test]
+    fn test_flow_sequence_push_string_with_spaces() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        let doc = Document::from_str("tags: [foo]").unwrap();
+        let seq = doc.get_path("tags").unwrap().as_sequence().unwrap().clone();
+        seq.push("hello world").unwrap();
+        assert_eq!(doc.to_string(), "tags: [foo, hello world]");
+    }
+
+    #[test]
+    fn test_flow_sequence_push_integer() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        let doc = Document::from_str("nums: [1, 2]").unwrap();
+        let seq = doc.get_path("nums").unwrap().as_sequence().unwrap().clone();
+        seq.push(3).unwrap();
+        assert_eq!(doc.to_string(), "nums: [1, 2, 3]");
+    }
+
+    #[test]
+    fn test_flow_sequence_push_multiple_to_empty() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        let doc = Document::from_str("seq: []").unwrap();
+        let seq = doc.get_path("seq").unwrap().as_sequence().unwrap().clone();
+        seq.push("a").unwrap();
+        seq.push("b").unwrap();
+        seq.push("c").unwrap();
+        assert_eq!(doc.to_string(), "seq: [a, b, c]");
+    }
+
+    #[test]
+    fn test_flow_sequence_push_preserves_surrounding() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        let doc = Document::from_str("before: 1\nseq: [a]\nafter: 2\n").unwrap();
+        let seq = doc.get_path("seq").unwrap().as_sequence().unwrap().clone();
+        seq.push("b").unwrap();
+        assert_eq!(doc.to_string(), "before: 1\nseq: [a, b]\nafter: 2\n");
+    }
+
+    #[test]
+    fn test_flow_sequence_push_nested_in_mapping() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        let doc = Document::from_str("config:\n  items: [x]\n  other: val\n").unwrap();
+        let seq = doc
+            .get_path("config.items")
+            .unwrap()
+            .as_sequence()
+            .unwrap()
+            .clone();
+        seq.push("y").unwrap();
+        assert_eq!(doc.to_string(), "config:\n  items: [x, y]\n  other: val\n");
+    }
+
+    #[test]
+    fn test_flow_sequence_push_flow_indicators() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        // Strings containing flow indicators must be quoted in flow context
+        let doc = Document::from_str("seq: [a]").unwrap();
+        let seq = doc.get_path("seq").unwrap().as_sequence().unwrap().clone();
+        seq.push("contains]bracket").unwrap();
+        assert_eq!(doc.to_string(), "seq: [a, 'contains]bracket']");
+
+        let doc = Document::from_str("seq: [a]").unwrap();
+        let seq = doc.get_path("seq").unwrap().as_sequence().unwrap().clone();
+        seq.push("has[open").unwrap();
+        assert_eq!(doc.to_string(), "seq: [a, 'has[open']");
+
+        let doc = Document::from_str("seq: [a]").unwrap();
+        let seq = doc.get_path("seq").unwrap().as_sequence().unwrap().clone();
+        seq.push("with,comma").unwrap();
+        assert_eq!(doc.to_string(), "seq: [a, 'with,comma']");
+
+        let doc = Document::from_str("seq: [a]").unwrap();
+        let seq = doc.get_path("seq").unwrap().as_sequence().unwrap().clone();
+        seq.push("has{brace").unwrap();
+        assert_eq!(doc.to_string(), "seq: [a, 'has{brace']");
+
+        // When string contains both single quote and flow indicator, use double quotes
+        let doc = Document::from_str("seq: [a]").unwrap();
+        let seq = doc.get_path("seq").unwrap().as_sequence().unwrap().clone();
+        seq.push("it's a [test]").unwrap();
+        assert_eq!(doc.to_string(), "seq: [a, \"it's a [test]\"]");
+    }
+
+    #[test]
+    fn test_flow_sequence_push_with_extra_whitespace() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        // Flow sequence with extra internal whitespace
+        let doc = Document::from_str("seq: [ a , b ]").unwrap();
+        let seq = doc.get_path("seq").unwrap().as_sequence().unwrap().clone();
+        seq.push("c").unwrap();
+        assert_eq!(doc.to_string(), "seq: [ a , b , c]");
+    }
+
+    #[test]
+    fn test_flow_sequence_push_block_mapping_node_rejected() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        // Pushing a block mapping into a flow sequence should return an error
+        let source = Document::from_str("key: value\nnested: true").unwrap();
+        let source_mapping = source.as_mapping().unwrap();
+        let source_node = crate::as_yaml::YamlNode::Mapping(source_mapping.clone());
+
+        let doc = Document::from_str("items: [a, b]").unwrap();
+        let seq = doc
+            .get_path("items")
+            .unwrap()
+            .as_sequence()
+            .unwrap()
+            .clone();
+        assert!(seq.push(source_node).is_err());
+        // Original sequence is unchanged
+        assert_eq!(doc.to_string(), "items: [a, b]");
+    }
+
+    #[test]
+    fn test_flow_sequence_push_block_sequence_node_rejected() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        // Pushing a block sequence into a flow sequence should return an error
+        let source = Document::from_str("- x\n- y\n- z").unwrap();
+        let source_seq = source.as_sequence().unwrap();
+        let source_node = crate::as_yaml::YamlNode::Sequence(source_seq.clone());
+
+        let doc = Document::from_str("items: [a, b]").unwrap();
+        let seq = doc
+            .get_path("items")
+            .unwrap()
+            .as_sequence()
+            .unwrap()
+            .clone();
+        assert!(seq.push(source_node).is_err());
+        // Original sequence is unchanged
+        assert_eq!(doc.to_string(), "items: [a, b]");
+    }
+
+    #[test]
+    fn test_flow_sequence_push_flow_mapping_node_accepted() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        // Pushing a flow mapping into a flow sequence should work
+        let source = Document::from_str("{key: value}").unwrap();
+        let source_mapping = source.as_mapping().unwrap();
+        let source_node = crate::as_yaml::YamlNode::Mapping(source_mapping.clone());
+
+        let doc = Document::from_str("items: [a, b]").unwrap();
+        let seq = doc
+            .get_path("items")
+            .unwrap()
+            .as_sequence()
+            .unwrap()
+            .clone();
+        seq.push(source_node).unwrap();
+        assert_eq!(doc.to_string(), "items: [a, b, {key: value}]");
+    }
+
+    #[test]
+    fn test_flow_sequence_push_flow_sequence_node_accepted() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        // Pushing a flow sequence into a flow sequence should work
+        let source = Document::from_str("[x, y]").unwrap();
+        let source_seq = source.as_sequence().unwrap();
+        let source_node = crate::as_yaml::YamlNode::Sequence(source_seq.clone());
+
+        let doc = Document::from_str("items: [a, b]").unwrap();
+        let seq = doc
+            .get_path("items")
+            .unwrap()
+            .as_sequence()
+            .unwrap()
+            .clone();
+        seq.push(source_node).unwrap();
+        assert_eq!(doc.to_string(), "items: [a, b, [x, y]]");
+    }
+
+    #[test]
+    fn test_block_sequence_push_block_mapping_accepted() {
+        use crate::path::YamlPath;
+        use crate::Document;
+        // Pushing a block mapping into a block sequence should work fine
+        let source = Document::from_str("key: value\nnested: true").unwrap();
+        let source_mapping = source.as_mapping().unwrap();
+        let source_node = crate::as_yaml::YamlNode::Mapping(source_mapping.clone());
+
+        let doc = Document::from_str("items:\n  - a\n  - b").unwrap();
+        let seq = doc
+            .get_path("items")
+            .unwrap()
+            .as_sequence()
+            .unwrap()
+            .clone();
+        seq.push(source_node).unwrap();
     }
 }

--- a/src/nodes/sequence.rs
+++ b/src/nodes/sequence.rs
@@ -365,8 +365,7 @@ impl Sequence {
                                     // trailing NEWLINE+INDENT that must be preserved.
                                     let text = n.text().to_string();
                                     if let Some(last_newline_pos) = text.rfind('\n') {
-                                        trailing_text =
-                                            Some(text[last_newline_pos..].to_string());
+                                        trailing_text = Some(text[last_newline_pos..].to_string());
                                     }
 
                                     // Replace the value node with the new value built from AsYaml
@@ -871,8 +870,8 @@ scores:
         let doc = Document::from_str(original).unwrap();
         let mapping = doc.as_mapping().unwrap();
         let config = mapping.get_mapping("config").unwrap();
-        config.set("enabled", false);
-        config.set("retries", 5);
+        config.set("enabled", false).unwrap();
+        config.set("retries", 5).unwrap();
 
         let servers = config.get_sequence("servers").unwrap();
         servers.push("host3").unwrap();

--- a/src/nodes/sequence.rs
+++ b/src/nodes/sequence.rs
@@ -1549,7 +1549,7 @@ scores:
         // Pushing a block mapping into a flow sequence should return an error
         let source = Document::from_str("key: value\nnested: true").unwrap();
         let source_mapping = source.as_mapping().unwrap();
-        let source_node = crate::as_yaml::YamlNode::Mapping(source_mapping.clone());
+        let source_node = crate::as_yaml::YamlNode::Mapping(source_mapping);
 
         let doc = Document::from_str("items: [a, b]").unwrap();
         let seq = doc
@@ -1570,7 +1570,7 @@ scores:
         // Pushing a block sequence into a flow sequence should return an error
         let source = Document::from_str("- x\n- y\n- z").unwrap();
         let source_seq = source.as_sequence().unwrap();
-        let source_node = crate::as_yaml::YamlNode::Sequence(source_seq.clone());
+        let source_node = crate::as_yaml::YamlNode::Sequence(source_seq);
 
         let doc = Document::from_str("items: [a, b]").unwrap();
         let seq = doc
@@ -1591,7 +1591,7 @@ scores:
         // Pushing a flow mapping into a flow sequence should work
         let source = Document::from_str("{key: value}").unwrap();
         let source_mapping = source.as_mapping().unwrap();
-        let source_node = crate::as_yaml::YamlNode::Mapping(source_mapping.clone());
+        let source_node = crate::as_yaml::YamlNode::Mapping(source_mapping);
 
         let doc = Document::from_str("items: [a, b]").unwrap();
         let seq = doc
@@ -1611,7 +1611,7 @@ scores:
         // Pushing a flow sequence into a flow sequence should work
         let source = Document::from_str("[x, y]").unwrap();
         let source_seq = source.as_sequence().unwrap();
-        let source_node = crate::as_yaml::YamlNode::Sequence(source_seq.clone());
+        let source_node = crate::as_yaml::YamlNode::Sequence(source_seq);
 
         let doc = Document::from_str("items: [a, b]").unwrap();
         let seq = doc
@@ -1631,7 +1631,7 @@ scores:
         // Pushing a block mapping into a block sequence should work fine
         let source = Document::from_str("key: value\nnested: true").unwrap();
         let source_mapping = source.as_mapping().unwrap();
-        let source_node = crate::as_yaml::YamlNode::Mapping(source_mapping.clone());
+        let source_node = crate::as_yaml::YamlNode::Mapping(source_mapping);
 
         let doc = Document::from_str("items:\n  - a\n  - b").unwrap();
         let seq = doc

--- a/src/path.rs
+++ b/src/path.rs
@@ -434,14 +434,94 @@ fn set_path_on_mapping<V: crate::AsYaml>(
         return Ok(());
     }
 
-    // Next segment is a key, so we need a mapping
-    if let Some(nested) = mapping.get_mapping(first_key) {
-        set_path_on_mapping(&nested, &segments[1..], value)?;
-    } else {
-        // Create empty mapping using Mapping::new() (avoids cross-document bugs)
-        mapping.set(first_key, Mapping::new())?;
-        if let Some(nested) = mapping.get_mapping(first_key) {
-            set_path_on_mapping(&nested, &segments[1..], value)?;
+    let next_segment = &segments[1];
+    match next_segment {
+        PathSegment::Key(_) => {
+            // Next segment is a key, so we need a mapping
+            if let Some(nested) = mapping.get_mapping(first_key) {
+                set_path_on_mapping(&nested, &segments[1..], value)?;
+            } else {
+                // Create empty mapping using YamlValue (avoids cross-document bugs)
+                mapping.set(first_key, Mapping::new())?;
+                if let Some(nested) = mapping.get_mapping(first_key) {
+                    set_path_on_mapping(&nested, &segments[1..], value)?;
+                }
+            }
+        }
+        PathSegment::Index(_) => {
+            // Next segment is an index, so we need a sequence
+            if let Some(nested) = mapping.get_sequence(first_key) {
+                set_path_on_sequence(&nested, &segments[1..], value)?;
+            } else {
+                // Create empty sequence using YamlValue (avoids cross-document bugs)
+                mapping.set(
+                    first_key,
+                    crate::value::YamlValue::Sequence(Default::default()),
+                )?;
+                if let Some(nested) = mapping.get_sequence(first_key) {
+                    set_path_on_sequence(&nested, &segments[1..], value)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Set a value at a path on a sequence, creating intermediate structures as needed.
+fn set_path_on_sequence<V: crate::AsYaml>(
+    seq: &crate::Sequence,
+    segments: &[PathSegment],
+    value: V,
+) -> Result<(), crate::error::YamlError> {
+    if segments.is_empty() {
+        return Ok(());
+    }
+
+    let index = match &segments[0] {
+        PathSegment::Index(idx) => *idx,
+        PathSegment::Key(_) => return Ok(()), // Can't set by key on a sequence
+    };
+
+    if segments.len() == 1 {
+        seq.set(index, value);
+        return Ok(());
+    }
+
+    // Ensure the item exists at `index`, filling with nulls if needed
+    if seq.get(index).is_none() {
+        while seq.len() <= index {
+            seq.push(crate::scalar::ScalarValue::null())?;
+        }
+    }
+
+    match &segments[1] {
+        PathSegment::Key(_) => {
+            // Next segment is a key — need a mapping at this index
+            let has_mapping = seq
+                .get(index)
+                .is_some_and(|item| item.as_mapping().is_some());
+            if !has_mapping {
+                seq.set(index, Mapping::new());
+            }
+            if let Some(item) = seq.get(index) {
+                if let Some(nested) = item.as_mapping() {
+                    set_path_on_mapping(nested, &segments[1..], value)?;
+                }
+            }
+        }
+        PathSegment::Index(_) => {
+            // Next segment is an index — need a sequence at this index
+            let has_sequence = seq
+                .get(index)
+                .is_some_and(|item| item.as_sequence().is_some());
+            if !has_sequence {
+                seq.set(index, crate::value::YamlValue::Sequence(Default::default()));
+            }
+            if let Some(item) = seq.get(index) {
+                if let Some(nested) = item.as_sequence() {
+                    set_path_on_sequence(nested, &segments[1..], value)?;
+                }
+            }
         }
     }
     Ok(())
@@ -1092,5 +1172,34 @@ config:
                 .map(|s| s.to_string()),
             Some("5432".to_string())
         );
+    }
+
+    #[test]
+    fn test_set_path_creates_intermediate_nodes() {
+        use std::str::FromStr;
+        let doc = crate::Document::from_str("base: true\n").unwrap();
+
+        // Setting a deeply nested path should create intermediate structures
+        doc.set_path("a.b[0].c", "value").unwrap();
+
+        // Verify the value is accessible via get_path
+        assert_eq!(
+            doc.get_path("a.b[0].c")
+                .as_ref()
+                .and_then(|v| v.as_scalar())
+                .map(|s| s.to_string()),
+            Some("value".to_string())
+        );
+    }
+
+    #[test]
+    fn test_set_path_into_sequence() {
+        use std::str::FromStr;
+        let doc = crate::Document::from_str("items:\n  - name: first\n").unwrap();
+
+        // Setting a nested value in an existing sequence item
+        doc.set_path("items[0].name", "updated").unwrap();
+
+        assert_eq!(doc.to_string(), "items:\n  - name: updated\n");
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -17,7 +17,7 @@
 //! let host = yaml.get_path("server.host");
 //!
 //! // Set nested values (creates intermediate mappings)
-//! yaml.set_path("database.primary.host", "db.example.com");
+//! yaml.set_path("database.primary.host", "db.example.com").unwrap();
 //!
 //! // Remove nested values
 //! yaml.remove_path("server.port");
@@ -25,7 +25,6 @@
 //!
 //! All operations preserve formatting, comments, and whitespace.
 
-use crate::builder::MappingBuilder;
 use crate::yaml::Mapping;
 
 /// Trait for YAML types that support path-based access.
@@ -74,10 +73,14 @@ pub trait YamlPath {
     /// use std::str::FromStr;
     ///
     /// let yaml = Document::from_str("name: test\n").unwrap();
-    /// yaml.set_path("server.host", "localhost");
-    /// yaml.set_path("server.port", 8080);
+    /// yaml.set_path("server.host", "localhost").unwrap();
+    /// yaml.set_path("server.port", 8080).unwrap();
     /// ```
-    fn set_path(&self, path: &str, value: impl crate::AsYaml);
+    fn set_path(
+        &self,
+        path: &str,
+        value: impl crate::AsYaml,
+    ) -> Result<(), crate::error::YamlError>;
 
     /// Remove a value at a nested path.
     ///
@@ -266,19 +269,23 @@ impl YamlPath for crate::yaml::Document {
         navigate_path(root, &segments)
     }
 
-    fn set_path(&self, path: &str, value: impl crate::AsYaml) {
+    fn set_path(
+        &self,
+        path: &str,
+        value: impl crate::AsYaml,
+    ) -> Result<(), crate::error::YamlError> {
         let segments = parse_path(path);
         if segments.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Get the root mapping (can only set paths on mappings at the root)
         let mapping = match self.as_mapping() {
             Some(m) => m,
-            None => return,
+            None => return Ok(()),
         };
 
-        set_path_impl(&mapping, &segments, value);
+        set_path_impl(&mapping, &segments, value)
     }
 
     fn remove_path(&self, path: &str) -> bool {
@@ -303,8 +310,12 @@ impl YamlPath for crate::yaml::Document {
 /// Set a value at a path, creating intermediate mappings as needed.
 ///
 /// This is used by Document::set_path() to handle the full path navigation.
-fn set_path_impl<V: crate::AsYaml>(mapping: &Mapping, segments: &[PathSegment], value: V) {
-    set_path_on_mapping(mapping, segments, value);
+fn set_path_impl<V: crate::AsYaml>(
+    mapping: &Mapping,
+    segments: &[PathSegment],
+    value: V,
+) -> Result<(), crate::error::YamlError> {
+    set_path_on_mapping(mapping, segments, value)
 }
 
 /// Remove a value at a nested path.
@@ -376,13 +387,17 @@ impl YamlPath for Mapping {
         navigate_path(current, &segments[1..])
     }
 
-    fn set_path(&self, path: &str, value: impl crate::AsYaml) {
+    fn set_path(
+        &self,
+        path: &str,
+        value: impl crate::AsYaml,
+    ) -> Result<(), crate::error::YamlError> {
         let segments = parse_path(path);
         if segments.is_empty() {
-            return;
+            return Ok(());
         }
 
-        set_path_on_mapping(self, &segments, value);
+        set_path_on_mapping(self, &segments, value)
     }
 
     fn remove_path(&self, path: &str) -> bool {
@@ -395,43 +410,41 @@ impl YamlPath for Mapping {
     }
 }
 
-/// Set a value at a path on a mapping, creating intermediate mappings as needed.
+/// Set a value at a path on a mapping, creating intermediate structures as needed.
 ///
 /// This function uses only the public API (get_mapping, set) and does NOT rebuild nodes.
-fn set_path_on_mapping<V: crate::AsYaml>(mapping: &Mapping, segments: &[PathSegment], value: V) {
+/// Uses YamlValue for intermediate structures to avoid cross-document node insertion bugs.
+fn set_path_on_mapping<V: crate::AsYaml>(
+    mapping: &Mapping,
+    segments: &[PathSegment],
+    value: V,
+) -> Result<(), crate::error::YamlError> {
     if segments.is_empty() {
-        return;
+        return Ok(());
     }
 
-    // First segment must be a key for mappings
     let first_key = match &segments[0] {
         PathSegment::Key(key) => key.as_str(),
-        PathSegment::Index(_) => return, // Can't set by index on a mapping
+        PathSegment::Index(_) => return Ok(()), // Can't set by index on a mapping
     };
 
     if segments.len() == 1 {
         // Base case: set directly
-        mapping.set(first_key, value);
-        return;
+        mapping.set(first_key, value)?;
+        return Ok(());
     }
 
-    // Try to navigate to existing nested mapping
+    // Next segment is a key, so we need a mapping
     if let Some(nested) = mapping.get_mapping(first_key) {
-        // Nested mapping exists, recurse
-        set_path_on_mapping(&nested, &segments[1..], value);
+        set_path_on_mapping(&nested, &segments[1..], value)?;
     } else {
-        // Need to create intermediate structure
-        let empty_mapping = MappingBuilder::new()
-            .build_document()
-            .as_mapping()
-            .expect("MappingBuilder always produces a mapping");
-        mapping.set(first_key, &empty_mapping);
-
-        // Retrieve and recurse into the newly created mapping
+        // Create empty mapping using Mapping::new() (avoids cross-document bugs)
+        mapping.set(first_key, Mapping::new())?;
         if let Some(nested) = mapping.get_mapping(first_key) {
-            set_path_on_mapping(&nested, &segments[1..], value);
+            set_path_on_mapping(&nested, &segments[1..], value)?;
         }
     }
+    Ok(())
 }
 
 /// Remove a value at a path from a mapping.
@@ -615,7 +628,7 @@ items:
         use crate::yaml::Document;
 
         let doc = Document::new();
-        doc.set("key.with.dots", "test value");
+        doc.set("key.with.dots", "test value").unwrap();
 
         // Without escaping - should not find it (looking for nested keys)
         assert!(doc.get_path("key.with.dots").is_none());
@@ -810,7 +823,7 @@ config:
 
         let yaml = Document::from_str("name: Alice\nage: 30\n").unwrap();
 
-        yaml.set_path("name", "Bob");
+        yaml.set_path("name", "Bob").unwrap();
 
         assert_eq!(yaml.to_string(), "name: Bob\nage: 30\n");
     }
@@ -822,7 +835,7 @@ config:
 
         let yaml = Document::from_str("name: Alice\n").unwrap();
 
-        yaml.set_path("age", 30);
+        yaml.set_path("age", 30).unwrap();
 
         assert_eq!(yaml.to_string(), "name: Alice\nage: 30\n");
     }
@@ -834,7 +847,7 @@ config:
 
         let yaml = Document::from_str("server:\n  host: localhost\n  port: 8080\n").unwrap();
 
-        yaml.set_path("server.port", 9000);
+        yaml.set_path("server.port", 9000).unwrap();
 
         assert_eq!(
             yaml.to_string(),
@@ -849,7 +862,7 @@ config:
 
         let yaml = Document::from_str("server:\n  host: localhost\n").unwrap();
 
-        yaml.set_path("server.port", 8080);
+        yaml.set_path("server.port", 8080).unwrap();
 
         assert_eq!(yaml.to_string(), "server:\n  host: localhost\nport: 8080\n");
     }
@@ -861,7 +874,7 @@ config:
 
         let yaml = Document::from_str("name: test\n").unwrap();
 
-        yaml.set_path("server.database.host", "localhost");
+        yaml.set_path("server.database.host", "localhost").unwrap();
 
         assert_eq!(
             yaml.to_string(),
@@ -883,10 +896,11 @@ config:
         use crate::yaml::Document;
         use std::str::FromStr;
 
-        let yaml = Document::from_str("app: {}\n").unwrap();
+        let yaml = Document::from_str("app:\n  name: test\n").unwrap();
 
-        yaml.set_path("app.database.primary.host", "db.example.com");
-        yaml.set_path("app.database.primary.port", 5432);
+        yaml.set_path("app.database.primary.host", "db.example.com")
+            .unwrap();
+        yaml.set_path("app.database.primary.port", 5432).unwrap();
 
         let host = yaml.get_path("app.database.primary.host");
         assert_eq!(
@@ -985,7 +999,7 @@ config:
         );
 
         // Set on mapping
-        mapping.set_path("server.port", 8080);
+        mapping.set_path("server.port", 8080).unwrap();
         assert_eq!(yaml.to_string(), "server:\n  host: localhost\nport: 8080\n");
 
         // Remove from mapping
@@ -1004,7 +1018,7 @@ config:
 
         let yaml = Document::from_str("server:\n  host: localhost  # production server\n").unwrap();
 
-        yaml.set_path("server.host", "newhost");
+        yaml.set_path("server.host", "newhost").unwrap();
 
         assert_eq!(
             yaml.to_string(),
@@ -1020,10 +1034,10 @@ config:
         let yaml = Document::from_str("name: test\n").unwrap();
 
         // Create nested structure
-        yaml.set_path("server.host", "localhost");
-        yaml.set_path("server.port", 8080);
-        yaml.set_path("database.host", "db.local");
-        yaml.set_path("database.port", 5432);
+        yaml.set_path("server.host", "localhost").unwrap();
+        yaml.set_path("server.port", 8080).unwrap();
+        yaml.set_path("database.host", "db.local").unwrap();
+        yaml.set_path("database.port", 5432).unwrap();
 
         // Verify all values
         assert_eq!(

--- a/src/path.rs
+++ b/src/path.rs
@@ -279,13 +279,14 @@ impl YamlPath for crate::yaml::Document {
             return Ok(());
         }
 
-        // Get the root mapping (can only set paths on mappings at the root)
-        let mapping = match self.as_mapping() {
-            Some(m) => m,
-            None => return Ok(()),
-        };
-
-        set_path_impl(&mapping, &segments, value)
+        // Dispatch based on root type
+        if let Some(mapping) = self.as_mapping() {
+            set_path_on_mapping(&mapping, &segments, value)
+        } else if let Some(sequence) = self.as_sequence() {
+            set_path_on_sequence(&sequence, &segments, value)
+        } else {
+            Ok(())
+        }
     }
 
     fn remove_path(&self, path: &str) -> bool {
@@ -294,74 +295,15 @@ impl YamlPath for crate::yaml::Document {
             return false;
         }
 
-        // Start from document root
-        let root = if let Some(m) = self.as_mapping() {
-            crate::as_yaml::YamlNode::Mapping(m)
-        } else if let Some(s) = self.as_sequence() {
-            crate::as_yaml::YamlNode::Sequence(s)
+        // Dispatch based on root type
+        if let Some(mapping) = self.as_mapping() {
+            remove_path_from_mapping(&mapping, &segments)
+        } else if let Some(sequence) = self.as_sequence() {
+            remove_path_from_sequence(&sequence, &segments)
         } else {
-            return false;
-        };
-
-        remove_path_impl(root, &segments)
-    }
-}
-
-/// Set a value at a path, creating intermediate mappings as needed.
-///
-/// This is used by Document::set_path() to handle the full path navigation.
-fn set_path_impl<V: crate::AsYaml>(
-    mapping: &Mapping,
-    segments: &[PathSegment],
-    value: V,
-) -> Result<(), crate::error::YamlError> {
-    set_path_on_mapping(mapping, segments, value)
-}
-
-/// Remove a value at a nested path.
-///
-/// This is used by Document::remove_path() to handle the full path navigation.
-fn remove_path_impl(root: crate::as_yaml::YamlNode, segments: &[PathSegment]) -> bool {
-    if segments.is_empty() {
-        return false;
-    }
-
-    if segments.len() == 1 {
-        // Base case: remove from the current node
-        match &segments[0] {
-            PathSegment::Key(key) => {
-                if let Some(mapping) = root.as_mapping() {
-                    return mapping.remove(key.as_str()).is_some();
-                }
-            }
-            PathSegment::Index(_) => {
-                // Removing by index from a sequence is not supported
-                // (would require shifting all subsequent elements)
-                return false;
-            }
-        }
-        return false;
-    }
-
-    // Navigate to the parent and recurse
-    match &segments[0] {
-        PathSegment::Key(key) => {
-            if let Some(mapping) = root.as_mapping() {
-                if let Some(nested) = mapping.get(key.as_str()) {
-                    return remove_path_impl(nested, &segments[1..]);
-                }
-            }
-        }
-        PathSegment::Index(index) => {
-            if let Some(sequence) = root.as_sequence() {
-                if let Some(nested) = sequence.get(*index) {
-                    return remove_path_impl(nested, &segments[1..]);
-                }
-            }
+            false
         }
     }
-
-    false
 }
 
 // Implementation for Mapping
@@ -407,6 +349,50 @@ impl YamlPath for Mapping {
         }
 
         remove_path_from_mapping(self, &segments)
+    }
+}
+
+// Implementation for Sequence
+impl YamlPath for crate::Sequence {
+    fn get_path(&self, path: &str) -> Option<crate::as_yaml::YamlNode> {
+        let segments = parse_path(path);
+        if segments.is_empty() {
+            return None;
+        }
+
+        let index = match &segments[0] {
+            PathSegment::Index(idx) => *idx,
+            PathSegment::Key(_) => return None, // Can't key into a sequence directly
+        };
+
+        let current = self.get(index)?;
+        if segments.len() == 1 {
+            return Some(current);
+        }
+
+        navigate_path(current, &segments[1..])
+    }
+
+    fn set_path(
+        &self,
+        path: &str,
+        value: impl crate::AsYaml,
+    ) -> Result<(), crate::error::YamlError> {
+        let segments = parse_path(path);
+        if segments.is_empty() {
+            return Ok(());
+        }
+
+        set_path_on_sequence(self, &segments, value)
+    }
+
+    fn remove_path(&self, path: &str) -> bool {
+        let segments = parse_path(path);
+        if segments.is_empty() {
+            return false;
+        }
+
+        remove_path_from_sequence(self, &segments)
     }
 }
 
@@ -535,22 +521,70 @@ fn remove_path_from_mapping(mapping: &Mapping, segments: &[PathSegment]) -> bool
         return false;
     }
 
-    // First segment must be a key for mappings
     let first_key = match &segments[0] {
         PathSegment::Key(key) => key.as_str(),
         PathSegment::Index(_) => return false, // Can't index into a mapping
     };
 
     if segments.len() == 1 {
-        // Base case: remove directly
         return mapping.remove(first_key).is_some();
     }
 
-    // Navigate to the parent mapping and recurse
-    if let Some(nested) = mapping.get_mapping(first_key) {
-        remove_path_from_mapping(&nested, &segments[1..])
-    } else {
-        false // Path doesn't exist
+    // Navigate into the value at this key and recurse
+    match &segments[1] {
+        PathSegment::Key(_) => {
+            if let Some(nested) = mapping.get_mapping(first_key) {
+                remove_path_from_mapping(&nested, &segments[1..])
+            } else {
+                false
+            }
+        }
+        PathSegment::Index(_) => {
+            if let Some(nested) = mapping.get_sequence(first_key) {
+                remove_path_from_sequence(&nested, &segments[1..])
+            } else {
+                false
+            }
+        }
+    }
+}
+
+/// Remove a value at a path from a sequence.
+fn remove_path_from_sequence(seq: &crate::Sequence, segments: &[PathSegment]) -> bool {
+    if segments.is_empty() {
+        return false;
+    }
+
+    let index = match &segments[0] {
+        PathSegment::Index(idx) => *idx,
+        PathSegment::Key(_) => return false, // Can't key into a sequence
+    };
+
+    if segments.len() == 1 {
+        return seq.remove(index).is_some();
+    }
+
+    // Navigate into the item at this index and recurse
+    let item = match seq.get(index) {
+        Some(item) => item,
+        None => return false,
+    };
+
+    match &segments[1] {
+        PathSegment::Key(_) => {
+            if let Some(nested) = item.as_mapping() {
+                remove_path_from_mapping(nested, &segments[1..])
+            } else {
+                false
+            }
+        }
+        PathSegment::Index(_) => {
+            if let Some(nested) = item.as_sequence() {
+                remove_path_from_sequence(nested, &segments[1..])
+            } else {
+                false
+            }
+        }
     }
 }
 
@@ -1201,5 +1235,118 @@ config:
         doc.set_path("items[0].name", "updated").unwrap();
 
         assert_eq!(doc.to_string(), "items:\n  - name: updated\n");
+    }
+
+    #[test]
+    fn test_remove_path_sequence_index() {
+        use crate::yaml::Document;
+        use std::str::FromStr;
+
+        let yaml = Document::from_str("items:\n  - first\n  - second\n  - third\n").unwrap();
+
+        assert!(yaml.remove_path("items[1]"));
+
+        let binding = yaml.get_path("items").unwrap();
+        let seq = binding.as_sequence().unwrap();
+        let values: Vec<String> = seq.values().map(|v| v.to_string()).collect();
+        assert_eq!(values, vec!["first", "third"]);
+    }
+
+    #[test]
+    fn test_remove_path_nested_in_sequence() {
+        use crate::yaml::Document;
+        use std::str::FromStr;
+
+        let yaml = Document::from_str("items:\n  - name: first\n    value: 1\n  - name: second\n")
+            .unwrap();
+
+        assert!(yaml.remove_path("items[0].value"));
+        assert_eq!(
+            yaml.get_path("items[0].name")
+                .as_ref()
+                .and_then(|v| v.as_scalar())
+                .map(|s| s.to_string()),
+            Some("first".to_string())
+        );
+        assert_eq!(yaml.get_path("items[0].value"), None);
+    }
+
+    #[test]
+    fn test_remove_path_sequence_index_out_of_bounds() {
+        use crate::yaml::Document;
+        use std::str::FromStr;
+
+        let yaml = Document::from_str("items:\n  - first\n").unwrap();
+        assert!(!yaml.remove_path("items[5]"));
+    }
+
+    #[test]
+    fn test_mapping_remove_path_through_sequence() {
+        use crate::yaml::Document;
+        use std::str::FromStr;
+
+        let yaml = Document::from_str("items:\n  - name: first\n    value: 1\n").unwrap();
+        let mapping = yaml.as_mapping().unwrap();
+
+        assert!(mapping.remove_path("items[0].value"));
+        assert_eq!(yaml.get_path("items[0].value"), None);
+        assert!(yaml.get_path("items[0].name").is_some());
+    }
+
+    #[test]
+    fn test_sequence_yaml_path() {
+        use crate::yaml::Document;
+        use std::str::FromStr;
+
+        let yaml = Document::from_str("- name: first\n  value: 1\n- name: second\n").unwrap();
+        let seq = yaml.as_sequence().unwrap();
+
+        // get_path
+        assert_eq!(
+            seq.get_path("[0].name")
+                .as_ref()
+                .and_then(|v| v.as_scalar())
+                .map(|s| s.to_string()),
+            Some("first".to_string())
+        );
+
+        // set_path
+        seq.set_path("[0].value", 42).unwrap();
+        assert_eq!(
+            seq.get_path("[0].value")
+                .as_ref()
+                .and_then(|v| v.as_scalar())
+                .map(|s| s.to_string()),
+            Some("42".to_string())
+        );
+
+        // remove_path
+        assert!(seq.remove_path("[1]"));
+        assert_eq!(seq.get_path("[1]"), None);
+    }
+
+    #[test]
+    fn test_document_set_path_sequence_root() {
+        use crate::yaml::Document;
+        use std::str::FromStr;
+
+        let yaml = Document::from_str("- name: first\n").unwrap();
+
+        yaml.set_path("[0].name", "updated").unwrap();
+        assert_eq!(yaml.to_string(), "- name: updated\n");
+    }
+
+    #[test]
+    fn test_document_remove_path_sequence_root() {
+        use crate::yaml::Document;
+        use std::str::FromStr;
+
+        let yaml = Document::from_str("- first\n- second\n- third\n").unwrap();
+
+        assert!(yaml.remove_path("[1]"));
+
+        let seq = yaml.as_sequence().unwrap();
+        let values: Vec<String> = seq.values().map(|v| v.to_string()).collect();
+        assert_eq!(values, vec!["first", "third"]);
     }
 }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -103,9 +103,16 @@ impl ScalarValue {
     /// For YAML-style type detection (parsing "123" as Integer, "true" as Boolean),
     /// use [`ScalarValue::parse()`] instead.
     pub fn string(value: impl Into<String>) -> Self {
+        Self::string_in_context(value, false)
+    }
+
+    /// Create a scalar value from a string, with flow-context-aware quoting.
+    ///
+    /// When `flow_context` is true, strings containing flow indicators
+    /// (`[`, `]`, `{`, `}`, `,`) will be quoted.
+    pub fn string_in_context(value: impl Into<String>, flow_context: bool) -> Self {
         let value = value.into();
-        let style = Self::detect_style(&value);
-        // Detect the type - default to String for user-provided values
+        let style = Self::detect_style_for_context(&value, flow_context);
         let scalar_type = ScalarType::String;
         Self {
             value,
@@ -813,8 +820,12 @@ impl ScalarValue {
 
     /// Detect the appropriate style for a value
     fn detect_style(value: &str) -> ScalarStyle {
+        Self::detect_style_for_context(value, false)
+    }
+
+    fn detect_style_for_context(value: &str, flow_context: bool) -> ScalarStyle {
         // Check if value needs quoting
-        if Self::needs_quoting(value) {
+        if Self::needs_quoting(value, flow_context) {
             // Prefer single quotes if no single quotes in value
             if !value.contains('\'') {
                 ScalarStyle::SingleQuoted
@@ -829,8 +840,12 @@ impl ScalarValue {
         }
     }
 
-    /// Check if a value needs quoting when treated as a string
-    fn needs_quoting(value: &str) -> bool {
+    /// Check if a value needs quoting when treated as a string.
+    ///
+    /// When `flow_context` is true, flow indicators (`[`, `]`, `{`, `}`, `,`)
+    /// anywhere in the string also trigger quoting, since they are syntactically
+    /// significant inside flow collections.
+    fn needs_quoting(value: &str, flow_context: bool) -> bool {
         // Empty string needs quotes
         if value.is_empty() {
             return true;
@@ -859,6 +874,11 @@ impl ScalarValue {
         if value.starts_with(|ch: char| {
             matches!(ch, '-' | '?' | '[' | ']' | '{' | '}' | ',' | '>' | '<')
         }) {
+            return true;
+        }
+
+        // In flow context, flow indicators anywhere in the string are ambiguous
+        if flow_context && value.contains(&['[', ']', '{', '}', ','] as &[char]) {
             return true;
         }
 
@@ -902,7 +922,7 @@ impl ScalarValue {
                 match self.scalar_type {
                     ScalarType::String => {
                         // For strings, quote if the content looks like a special value
-                        if Self::needs_quoting(&self.value) {
+                        if Self::needs_quoting(&self.value, false) {
                             self.to_single_quoted()
                         } else {
                             self.value.clone()

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -97,9 +97,16 @@ impl ScalarValue {
     /// For YAML-style type detection (parsing "123" as Integer, "true" as Boolean),
     /// use [`ScalarValue::parse()`] instead.
     pub fn string(value: impl Into<String>) -> Self {
+        Self::string_in_context(value, false)
+    }
+
+    /// Create a scalar value from a string, with flow-context-aware quoting.
+    ///
+    /// When `flow_context` is true, strings containing flow indicators
+    /// (`[`, `]`, `{`, `}`, `,`) will be quoted.
+    pub fn string_in_context(value: impl Into<String>, flow_context: bool) -> Self {
         let value = value.into();
-        let style = Self::detect_style(&value);
-        // Detect the type - default to String for user-provided values
+        let style = Self::detect_style_for_context(&value, flow_context);
         let scalar_type = ScalarType::String;
         Self {
             value,
@@ -807,8 +814,12 @@ impl ScalarValue {
 
     /// Detect the appropriate style for a value
     fn detect_style(value: &str) -> ScalarStyle {
+        Self::detect_style_for_context(value, false)
+    }
+
+    fn detect_style_for_context(value: &str, flow_context: bool) -> ScalarStyle {
         // Check if value needs quoting
-        if Self::needs_quoting(value) {
+        if Self::needs_quoting(value, flow_context) {
             // Prefer single quotes if no single quotes in value
             if !value.contains('\'') {
                 ScalarStyle::SingleQuoted
@@ -823,8 +834,12 @@ impl ScalarValue {
         }
     }
 
-    /// Check if a value needs quoting when treated as a string
-    fn needs_quoting(value: &str) -> bool {
+    /// Check if a value needs quoting when treated as a string.
+    ///
+    /// When `flow_context` is true, flow indicators (`[`, `]`, `{`, `}`, `,`)
+    /// anywhere in the string also trigger quoting, since they are syntactically
+    /// significant inside flow collections.
+    fn needs_quoting(value: &str, flow_context: bool) -> bool {
         // Empty string needs quotes
         if value.is_empty() {
             return true;
@@ -853,6 +868,11 @@ impl ScalarValue {
         if value.starts_with(|ch: char| {
             matches!(ch, '-' | '?' | '[' | ']' | '{' | '}' | ',' | '>' | '<')
         }) {
+            return true;
+        }
+
+        // In flow context, flow indicators anywhere in the string are ambiguous
+        if flow_context && value.contains(&['[', ']', '{', '}', ','] as &[char]) {
             return true;
         }
 
@@ -894,7 +914,7 @@ impl ScalarValue {
                 match self.scalar_type {
                     ScalarType::String => {
                         // For strings, quote if the content looks like a special value
-                        if Self::needs_quoting(&self.value) {
+                        if Self::needs_quoting(&self.value, false) {
                             self.to_single_quoted()
                         } else {
                             self.value.clone()

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -384,10 +384,15 @@ impl YamlFile {
     /// need to guarantee a document exists.
     ///
     /// Mutates in place despite `&self` (see crate docs on interior mutability).
-    pub fn set(&self, key: impl crate::AsYaml, value: impl crate::AsYaml) {
+    pub fn set(
+        &self,
+        key: impl crate::AsYaml,
+        value: impl crate::AsYaml,
+    ) -> Result<(), crate::error::YamlError> {
         if let Some(doc) = self.document() {
-            doc.set(key, value);
+            doc.set(key, value)?;
         }
+        Ok(())
     }
 
     /// Insert a key-value pair immediately after `after_key` in the first document.
@@ -403,11 +408,11 @@ impl YamlFile {
         after_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(doc) = self.document() {
             doc.insert_after(after_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -424,11 +429,11 @@ impl YamlFile {
         before_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(doc) = self.document() {
             doc.insert_before(before_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -447,11 +452,11 @@ impl YamlFile {
         after_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(doc) = self.document() {
             doc.move_after(after_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -470,11 +475,11 @@ impl YamlFile {
         before_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(doc) = self.document() {
             doc.move_before(before_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -491,10 +496,9 @@ impl YamlFile {
         index: usize,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) {
+    ) -> Result<(), crate::error::YamlError> {
         if let Some(doc) = self.document() {
-            doc.insert_at_index(index, key, value);
-            // Mutations happen directly on the document, no need to replace
+            doc.insert_at_index(index, key, value)?;
         } else {
             // If no document exists, create one without the --- marker for consistency
             // with normal parsed YAML
@@ -510,9 +514,10 @@ impl YamlFile {
 
             // Now get the document again and insert
             if let Some(doc) = self.document() {
-                doc.insert_at_index(index, key, value);
+                doc.insert_at_index(index, key, value)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -4951,8 +4956,8 @@ config:
         // Test basic editing operations
         let yaml = YamlFile::from_str("name: old-name\nversion: 1.0.0").unwrap();
         if let Some(doc) = yaml.document() {
-            doc.set("name", "new-name");
-            doc.set("version", "2.0.0");
+            doc.set("name", "new-name").unwrap();
+            doc.set("version", "2.0.0").unwrap();
 
             // Verify values can be retrieved via API
             assert_eq!(doc.get_string("name"), Some("new-name".to_string()));
@@ -5386,7 +5391,7 @@ patterns:
             .build_document()
             .as_sequence()
             .unwrap();
-        let success = doc.insert_after("name", "features", features);
+        let success = doc.insert_after("name", "features", features).unwrap();
         assert!(success, "insert_after should succeed");
 
         let output = doc.to_string();
@@ -5418,7 +5423,7 @@ version: 1.0.0"#;
             .build_document()
             .as_mapping()
             .unwrap();
-        let success = doc.insert_before("version", "database", database);
+        let success = doc.insert_before("version", "database", database).unwrap();
         assert!(success, "insert_before should succeed");
 
         let output = doc.to_string();
@@ -5468,9 +5473,9 @@ version: 1.0.0"#;
         let doc = parsed.document().expect("Should have a document");
 
         // Insert different types at various indices
-        doc.insert_at_index(1, "version", "1.0.0");
-        doc.insert_at_index(2, "active", true);
-        doc.insert_at_index(3, "count", 42);
+        doc.insert_at_index(1, "version", "1.0.0").unwrap();
+        doc.insert_at_index(2, "active", true).unwrap();
+        doc.insert_at_index(3, "count", 42).unwrap();
 
         let features = SequenceBuilder::new()
             .item("auth")
@@ -5478,7 +5483,7 @@ version: 1.0.0"#;
             .build_document()
             .as_sequence()
             .unwrap();
-        doc.insert_at_index(4, "features", features);
+        doc.insert_at_index(4, "features", features).unwrap();
 
         let output = doc.to_string();
 
@@ -5529,10 +5534,11 @@ features:
         let doc = parsed.document().expect("Should have a document");
 
         // Insert various scalar types
-        doc.insert_after("name", "null_value", ScalarValue::null());
-        doc.insert_after("null_value", "empty_string", "");
-        doc.insert_after("empty_string", "number", 1.234);
-        doc.insert_after("number", "boolean", false);
+        doc.insert_after("name", "null_value", ScalarValue::null())
+            .unwrap();
+        doc.insert_after("null_value", "empty_string", "").unwrap();
+        doc.insert_after("empty_string", "number", 1.234).unwrap();
+        doc.insert_after("number", "boolean", false).unwrap();
 
         let output = doc.to_string();
 
@@ -5588,8 +5594,8 @@ boolean: false"#;
         let doc = parsed.document().expect("Should have a document");
 
         // Insert items to create proper ordering
-        doc.insert_after("first", "second", 2);
-        doc.insert_before("fifth", "fourth", 4);
+        doc.insert_after("first", "second", 2).unwrap();
+        doc.insert_before("fifth", "fourth", 4).unwrap();
 
         let output = doc.to_string();
 
@@ -5614,18 +5620,20 @@ fifth: 5"#;
         // Test positioning with different value types
 
         // Position after a string value
-        let success = doc.insert_after("name", "description", "A sample project");
+        let success = doc
+            .insert_after("name", "description", "A sample project")
+            .unwrap();
         assert!(success, "Should find string key");
 
         // Position after a numeric value
-        let success = doc.insert_after(1.0, "build", "gradle");
+        let success = doc.insert_after(1.0, "build", "gradle").unwrap();
         assert!(
             !success,
             "Should not find numeric key (1.0) when actual key is string 'version'"
         );
 
         // Position after a boolean value
-        let success = doc.insert_after(true, "test", "enabled");
+        let success = doc.insert_after(true, "test", "enabled").unwrap();
         assert!(
             !success,
             "Should not find boolean key (true) when actual key is string 'active'"
@@ -5633,7 +5641,9 @@ fifth: 5"#;
 
         // But string representation should work
         let bool_string_key = "true";
-        let success = doc.insert_after(bool_string_key, "test_mode", "development");
+        let success = doc
+            .insert_after(bool_string_key, "test_mode", "development")
+            .unwrap();
         assert!(!success, "Should not find 'true' key when value is true");
 
         let output = doc.to_string();
@@ -5658,7 +5668,7 @@ fifth: 5"#;
             .as_mapping()
             .unwrap();
 
-        doc.insert_after("name", "config", config);
+        doc.insert_after("name", "config", config).unwrap();
 
         let output = doc.to_string();
 
@@ -5721,7 +5731,7 @@ fifth: 5"#;
         tags.insert("web".to_string());
 
         let yaml_set = YamlValue::from_set(tags);
-        doc.insert_after("name", "tags", yaml_set);
+        doc.insert_after("name", "tags", yaml_set).unwrap();
 
         let output = doc.to_string();
 
@@ -5784,7 +5794,7 @@ fifth: 5"#;
         ];
 
         let yaml_omap = YamlValue::from_ordered_mapping(ordered_steps);
-        doc.insert_after("name", "build_steps", yaml_omap);
+        doc.insert_after("name", "build_steps", yaml_omap).unwrap();
 
         let output = doc.to_string();
 
@@ -5864,7 +5874,7 @@ fifth: 5"#;
         ];
 
         let yaml_pairs = YamlValue::from_pairs(connection_attempts);
-        doc.insert_after("name", "connections", yaml_pairs);
+        doc.insert_after("name", "connections", yaml_pairs).unwrap();
 
         let output = doc.to_string();
 
@@ -5951,7 +5961,7 @@ fifth: 5"#;
         let empty_seq_yaml = YamlFile::from_str("[]").unwrap();
         let empty_list = empty_seq_yaml.document().unwrap().as_sequence().unwrap();
 
-        doc1.insert_after("name", "empty_list", empty_list);
+        doc1.insert_after("name", "empty_list", empty_list).unwrap();
         let output1 = doc1.to_string();
         assert_eq!(output1, "name: project\nempty_list: []\n");
 
@@ -5964,7 +5974,7 @@ fifth: 5"#;
         let empty_map_yaml = YamlFile::from_str("{}").unwrap();
         let empty_map = empty_map_yaml.document().unwrap().as_mapping().unwrap();
 
-        doc2.insert_after("name", "empty_map", empty_map);
+        doc2.insert_after("name", "empty_map", empty_map).unwrap();
         let output2 = doc2.to_string();
         assert_eq!(output2, "name: project\nempty_map: {}\n");
 
@@ -5972,7 +5982,8 @@ fifth: 5"#;
         let yaml3 = "name: project";
         let parsed3 = YamlFile::from_str(yaml3).unwrap();
         let doc3 = parsed3.document().expect("Should have a document");
-        doc3.insert_after("name", "empty_set", YamlValue::set());
+        doc3.insert_after("name", "empty_set", YamlValue::set())
+            .unwrap();
         let output3 = doc3.to_string();
         assert_eq!(output3, "name: project\nempty_set: !!set {}\n");
 
@@ -6009,7 +6020,8 @@ fifth: 5"#;
             .as_sequence()
             .unwrap();
 
-        doc.insert_after("name", "nested_data", nested_data);
+        doc.insert_after("name", "nested_data", nested_data)
+            .unwrap();
 
         let output = doc.to_string();
 
@@ -6076,7 +6088,7 @@ key2: value2  # Inline comment 2
 
         // Insert a new key, re-inserting it if it already exists - changes propagate automatically
         if let Some(mapping) = doc.as_mapping() {
-            mapping.move_after("key1", "new_key", "new_value");
+            mapping.move_after("key1", "new_key", "new_value").unwrap();
         }
 
         let result = doc.to_string();
@@ -6105,7 +6117,7 @@ key2:        value2
 
         // Insert a new key using AST-preserving method
         if let Some(mapping) = doc.as_mapping() {
-            mapping.move_after("key1", "new_key", "new_value");
+            mapping.move_after("key1", "new_key", "new_value").unwrap();
         }
 
         let result = doc.to_string();
@@ -6143,7 +6155,7 @@ server:
 
         // Insert a new top-level key
         if let Some(mapping) = doc.as_mapping() {
-            mapping.move_after("database", "logging", "debug");
+            mapping.move_after("database", "logging", "debug").unwrap();
         }
 
         let result = doc.to_string();

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -451,10 +451,15 @@ impl YamlFile {
     /// need to guarantee a document exists.
     ///
     /// Mutates in place despite `&self` (see crate docs on interior mutability).
-    pub fn set(&self, key: impl crate::AsYaml, value: impl crate::AsYaml) {
+    pub fn set(
+        &self,
+        key: impl crate::AsYaml,
+        value: impl crate::AsYaml,
+    ) -> Result<(), crate::error::YamlError> {
         if let Some(doc) = self.document() {
-            doc.set(key, value);
+            doc.set(key, value)?;
         }
+        Ok(())
     }
 
     /// Insert a key-value pair immediately after `after_key` in the first document.
@@ -470,11 +475,11 @@ impl YamlFile {
         after_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(doc) = self.document() {
             doc.insert_after(after_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -491,11 +496,11 @@ impl YamlFile {
         before_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(doc) = self.document() {
             doc.insert_before(before_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -514,11 +519,11 @@ impl YamlFile {
         after_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(doc) = self.document() {
             doc.move_after(after_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -537,11 +542,11 @@ impl YamlFile {
         before_key: impl crate::AsYaml,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) -> bool {
+    ) -> Result<bool, crate::error::YamlError> {
         if let Some(doc) = self.document() {
             doc.move_before(before_key, key, value)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -558,10 +563,9 @@ impl YamlFile {
         index: usize,
         key: impl crate::AsYaml,
         value: impl crate::AsYaml,
-    ) {
+    ) -> Result<(), crate::error::YamlError> {
         if let Some(doc) = self.document() {
-            doc.insert_at_index(index, key, value);
-            // Mutations happen directly on the document, no need to replace
+            doc.insert_at_index(index, key, value)?;
         } else {
             // If no document exists, create one without the --- marker for consistency
             // with normal parsed YAML
@@ -577,9 +581,10 @@ impl YamlFile {
 
             // Now get the document again and insert
             if let Some(doc) = self.document() {
-                doc.insert_at_index(index, key, value);
+                doc.insert_at_index(index, key, value)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -5166,8 +5171,8 @@ config:
         // Test basic editing operations
         let yaml = YamlFile::from_str("name: old-name\nversion: 1.0.0").unwrap();
         if let Some(doc) = yaml.document() {
-            doc.set("name", "new-name");
-            doc.set("version", "2.0.0");
+            doc.set("name", "new-name").unwrap();
+            doc.set("version", "2.0.0").unwrap();
 
             // Verify values can be retrieved via API
             assert_eq!(doc.get_string("name"), Some("new-name".to_string()));
@@ -5601,7 +5606,7 @@ patterns:
             .build_document()
             .as_sequence()
             .unwrap();
-        let success = doc.insert_after("name", "features", features);
+        let success = doc.insert_after("name", "features", features).unwrap();
         assert!(success, "insert_after should succeed");
 
         let output = doc.to_string();
@@ -5633,7 +5638,7 @@ version: 1.0.0"#;
             .build_document()
             .as_mapping()
             .unwrap();
-        let success = doc.insert_before("version", "database", database);
+        let success = doc.insert_before("version", "database", database).unwrap();
         assert!(success, "insert_before should succeed");
 
         let output = doc.to_string();
@@ -5683,9 +5688,9 @@ version: 1.0.0"#;
         let doc = parsed.document().expect("Should have a document");
 
         // Insert different types at various indices
-        doc.insert_at_index(1, "version", "1.0.0");
-        doc.insert_at_index(2, "active", true);
-        doc.insert_at_index(3, "count", 42);
+        doc.insert_at_index(1, "version", "1.0.0").unwrap();
+        doc.insert_at_index(2, "active", true).unwrap();
+        doc.insert_at_index(3, "count", 42).unwrap();
 
         let features = SequenceBuilder::new()
             .item("auth")
@@ -5693,7 +5698,7 @@ version: 1.0.0"#;
             .build_document()
             .as_sequence()
             .unwrap();
-        doc.insert_at_index(4, "features", features);
+        doc.insert_at_index(4, "features", features).unwrap();
 
         let output = doc.to_string();
 
@@ -5744,10 +5749,11 @@ features:
         let doc = parsed.document().expect("Should have a document");
 
         // Insert various scalar types
-        doc.insert_after("name", "null_value", ScalarValue::null());
-        doc.insert_after("null_value", "empty_string", "");
-        doc.insert_after("empty_string", "number", 1.234);
-        doc.insert_after("number", "boolean", false);
+        doc.insert_after("name", "null_value", ScalarValue::null())
+            .unwrap();
+        doc.insert_after("null_value", "empty_string", "").unwrap();
+        doc.insert_after("empty_string", "number", 1.234).unwrap();
+        doc.insert_after("number", "boolean", false).unwrap();
 
         let output = doc.to_string();
 
@@ -5803,8 +5809,8 @@ boolean: false"#;
         let doc = parsed.document().expect("Should have a document");
 
         // Insert items to create proper ordering
-        doc.insert_after("first", "second", 2);
-        doc.insert_before("fifth", "fourth", 4);
+        doc.insert_after("first", "second", 2).unwrap();
+        doc.insert_before("fifth", "fourth", 4).unwrap();
 
         let output = doc.to_string();
 
@@ -5829,18 +5835,20 @@ fifth: 5"#;
         // Test positioning with different value types
 
         // Position after a string value
-        let success = doc.insert_after("name", "description", "A sample project");
+        let success = doc
+            .insert_after("name", "description", "A sample project")
+            .unwrap();
         assert!(success, "Should find string key");
 
         // Position after a numeric value
-        let success = doc.insert_after(1.0, "build", "gradle");
+        let success = doc.insert_after(1.0, "build", "gradle").unwrap();
         assert!(
             !success,
             "Should not find numeric key (1.0) when actual key is string 'version'"
         );
 
         // Position after a boolean value
-        let success = doc.insert_after(true, "test", "enabled");
+        let success = doc.insert_after(true, "test", "enabled").unwrap();
         assert!(
             !success,
             "Should not find boolean key (true) when actual key is string 'active'"
@@ -5848,7 +5856,9 @@ fifth: 5"#;
 
         // But string representation should work
         let bool_string_key = "true";
-        let success = doc.insert_after(bool_string_key, "test_mode", "development");
+        let success = doc
+            .insert_after(bool_string_key, "test_mode", "development")
+            .unwrap();
         assert!(!success, "Should not find 'true' key when value is true");
 
         let output = doc.to_string();
@@ -5873,7 +5883,7 @@ fifth: 5"#;
             .as_mapping()
             .unwrap();
 
-        doc.insert_after("name", "config", config);
+        doc.insert_after("name", "config", config).unwrap();
 
         let output = doc.to_string();
 
@@ -5936,7 +5946,7 @@ fifth: 5"#;
         tags.insert("web".to_string());
 
         let yaml_set = YamlValue::from_set(tags);
-        doc.insert_after("name", "tags", yaml_set);
+        doc.insert_after("name", "tags", yaml_set).unwrap();
 
         let output = doc.to_string();
 
@@ -5999,7 +6009,7 @@ fifth: 5"#;
         ];
 
         let yaml_omap = YamlValue::from_ordered_mapping(ordered_steps);
-        doc.insert_after("name", "build_steps", yaml_omap);
+        doc.insert_after("name", "build_steps", yaml_omap).unwrap();
 
         let output = doc.to_string();
 
@@ -6079,7 +6089,7 @@ fifth: 5"#;
         ];
 
         let yaml_pairs = YamlValue::from_pairs(connection_attempts);
-        doc.insert_after("name", "connections", yaml_pairs);
+        doc.insert_after("name", "connections", yaml_pairs).unwrap();
 
         let output = doc.to_string();
 
@@ -6166,7 +6176,7 @@ fifth: 5"#;
         let empty_seq_yaml = YamlFile::from_str("[]").unwrap();
         let empty_list = empty_seq_yaml.document().unwrap().as_sequence().unwrap();
 
-        doc1.insert_after("name", "empty_list", empty_list);
+        doc1.insert_after("name", "empty_list", empty_list).unwrap();
         let output1 = doc1.to_string();
         assert_eq!(output1, "name: project\nempty_list: []\n");
 
@@ -6179,7 +6189,7 @@ fifth: 5"#;
         let empty_map_yaml = YamlFile::from_str("{}").unwrap();
         let empty_map = empty_map_yaml.document().unwrap().as_mapping().unwrap();
 
-        doc2.insert_after("name", "empty_map", empty_map);
+        doc2.insert_after("name", "empty_map", empty_map).unwrap();
         let output2 = doc2.to_string();
         assert_eq!(output2, "name: project\nempty_map: {}\n");
 
@@ -6187,7 +6197,8 @@ fifth: 5"#;
         let yaml3 = "name: project";
         let parsed3 = YamlFile::from_str(yaml3).unwrap();
         let doc3 = parsed3.document().expect("Should have a document");
-        doc3.insert_after("name", "empty_set", YamlValue::set());
+        doc3.insert_after("name", "empty_set", YamlValue::set())
+            .unwrap();
         let output3 = doc3.to_string();
         assert_eq!(output3, "name: project\nempty_set: !!set {}\n");
 
@@ -6224,7 +6235,8 @@ fifth: 5"#;
             .as_sequence()
             .unwrap();
 
-        doc.insert_after("name", "nested_data", nested_data);
+        doc.insert_after("name", "nested_data", nested_data)
+            .unwrap();
 
         let output = doc.to_string();
 
@@ -6291,7 +6303,7 @@ key2: value2  # Inline comment 2
 
         // Insert a new key, re-inserting it if it already exists - changes propagate automatically
         if let Some(mapping) = doc.as_mapping() {
-            mapping.move_after("key1", "new_key", "new_value");
+            mapping.move_after("key1", "new_key", "new_value").unwrap();
         }
 
         let result = doc.to_string();
@@ -6320,7 +6332,7 @@ key2:        value2
 
         // Insert a new key using AST-preserving method
         if let Some(mapping) = doc.as_mapping() {
-            mapping.move_after("key1", "new_key", "new_value");
+            mapping.move_after("key1", "new_key", "new_value").unwrap();
         }
 
         let result = doc.to_string();
@@ -6358,7 +6370,7 @@ server:
 
         // Insert a new top-level key
         if let Some(mapping) = doc.as_mapping() {
-            mapping.move_after("database", "logging", "debug");
+            mapping.move_after("database", "logging", "debug").unwrap();
         }
 
         let result = doc.to_string();

--- a/tests/insert_index_tests.rs
+++ b/tests/insert_index_tests.rs
@@ -4,7 +4,7 @@ use yaml_edit::{Document, YamlFile};
 #[test]
 fn test_insert_at_index_empty_document() {
     let yaml = YamlFile::from_str("").unwrap();
-    yaml.insert_at_index(0, "first", "value");
+    yaml.insert_at_index(0, "first", "value").unwrap();
 
     // Verify via API first
     let doc = yaml.document().expect("Should have document");
@@ -24,7 +24,7 @@ fn test_insert_at_index_update_existing() {
     let yaml = YamlFile::from_str("first: 1\nsecond: 2\nthird: 3").unwrap();
 
     // Update existing key
-    yaml.insert_at_index(2, "first", "updated");
+    yaml.insert_at_index(2, "first", "updated").unwrap();
 
     // Verify via API first
     let doc = yaml.document().expect("Should have document");
@@ -44,7 +44,7 @@ fn test_insert_at_index_new_key_at_beginning() {
     let yaml = YamlFile::from_str("first: 1\nsecond: 2").unwrap();
 
     // Insert new key at beginning
-    yaml.insert_at_index(0, "zero", "0");
+    yaml.insert_at_index(0, "zero", "0").unwrap();
 
     // Verify via API first
     let doc = yaml.document().expect("Should have document");
@@ -88,7 +88,7 @@ fn test_insert_at_index_new_key_in_middle() {
     let yaml = YamlFile::from_str("first: 1\nthird: 3").unwrap();
 
     // Insert new key in middle
-    yaml.insert_at_index(1, "second", "2");
+    yaml.insert_at_index(1, "second", "2").unwrap();
 
     // Verify via API first
     let doc = yaml.document().expect("Should have document");
@@ -138,7 +138,7 @@ fn test_insert_at_index_preserves_document_structure() {
     assert_eq!(pairs_before, 2, "Should have 2 pairs initially");
 
     // Insert new key
-    yaml.insert_at_index(1, "author", "developer");
+    yaml.insert_at_index(1, "author", "developer").unwrap();
 
     // Document structure should still be valid
     let doc_after = yaml.document().expect("Should still have document");
@@ -164,11 +164,11 @@ fn test_insert_at_index_preserves_document_structure() {
 #[test]
 fn test_document_insert_at_index() {
     let doc = Document::new();
-    doc.set("first", 1);
-    doc.set("second", 2);
+    doc.set("first", 1).unwrap();
+    doc.set("second", 2).unwrap();
 
     // Insert new key
-    doc.insert_at_index(1, "middle", 1.5);
+    doc.insert_at_index(1, "middle", 1.5).unwrap();
 
     let output = doc.to_string();
     let expected = "---
@@ -189,9 +189,11 @@ fn test_insert_special_characters() {
     let yaml = YamlFile::from_str("key1: value1").unwrap();
 
     // Test various special characters
-    yaml.insert_at_index(1, "special:key", "value:with:colons");
-    yaml.insert_at_index(0, "key with spaces", "value with spaces");
-    yaml.insert_at_index(2, "key@symbol", "value#hash");
+    yaml.insert_at_index(1, "special:key", "value:with:colons")
+        .unwrap();
+    yaml.insert_at_index(0, "key with spaces", "value with spaces")
+        .unwrap();
+    yaml.insert_at_index(2, "key@symbol", "value#hash").unwrap();
 
     // Verify via API first
     let doc = yaml.document().expect("Should have document");
@@ -252,7 +254,7 @@ fn test_insert_maintains_pairs_count() {
     assert_eq!(pairs_before, 3, "Should have 3 pairs initially");
 
     // Update existing key
-    yaml.insert_at_index(1, "b", "updated");
+    yaml.insert_at_index(1, "b", "updated").unwrap();
 
     let doc_after = yaml.document().expect("Should have document");
     let mapping_after = doc_after.as_mapping().expect("Should be mapping");
@@ -260,7 +262,7 @@ fn test_insert_maintains_pairs_count() {
     assert_eq!(pairs_after, 3, "Should still have 3 pairs after update");
 
     // Insert new key
-    yaml.insert_at_index(2, "d", "4");
+    yaml.insert_at_index(2, "d", "4").unwrap();
 
     let doc_final = yaml.document().expect("Should have document");
     let mapping_final = doc_final.as_mapping().expect("Should be mapping");

--- a/tests/multi_key_parsing_test.rs
+++ b/tests/multi_key_parsing_test.rs
@@ -149,7 +149,7 @@ third: https://third.example.com
     assert_eq!(doc.keys().count(), 3);
 
     // Edit a value
-    doc.set("second", "https://updated.example.com");
+    doc.set("second", "https://updated.example.com").unwrap();
 
     // Verify the edit worked and other keys remain unchanged
     assert_eq!(
@@ -166,7 +166,7 @@ third: https://third.example.com
     );
 
     // Add a new key
-    doc.set("fourth", "https://fourth.example.com");
+    doc.set("fourth", "https://fourth.example.com").unwrap();
     assert_eq!(doc.keys().count(), 4);
     assert_eq!(
         doc.get_string("fourth").unwrap(),

--- a/tests/mutation_edge_cases_test.rs
+++ b/tests/mutation_edge_cases_test.rs
@@ -30,7 +30,7 @@ ref: *x"#;
     assert_eq!(ref_val.as_alias().unwrap().name(), "x");
 
     // Mutate the anchored value
-    mapping.set("anchor", "modified");
+    mapping.set("anchor", "modified").unwrap();
 
     // Verify the anchor value changed
     let new_anchor_val = mapping.get("anchor").expect("Should have anchor");
@@ -69,8 +69,8 @@ server: *defaults"#;
     );
 
     // Mutate the anchored mapping
-    config.set("timeout", 60);
-    config.set("max_connections", 100);
+    config.set("timeout", 60).unwrap();
+    config.set("max_connections", 100).unwrap();
 
     // Verify the config mapping changed
     assert_eq!(
@@ -145,7 +145,7 @@ fn test_edit_block_scalar_content() {
     assert_eq!(initial_text, "Line 1\nLine 2\n");
 
     // Replace the block scalar with new content
-    mapping.set("text", "New single line");
+    mapping.set("text", "New single line").unwrap();
 
     // Verify the content changed
     let new_text_val = mapping.get("text").expect("Should have text");
@@ -176,7 +176,7 @@ fn test_replace_block_scalar_with_multiline() {
     // Note: We're setting a string value, which may render as plain/quoted scalar
     // depending on the implementation's formatting choices
     let new_content = "New line 1\nNew line 2\nNew line 3";
-    mapping.set("description", new_content);
+    mapping.set("description", new_content).unwrap();
 
     // Verify the content changed
     let new_val = mapping.get("description").expect("Should have description");
@@ -216,8 +216,8 @@ count: !!int 42"#;
 
     // Mutate the tagged values
     // Note: This replaces the tagged node with a plain scalar
-    mapping.set("date", "2024-12-31");
-    mapping.set("count", 100);
+    mapping.set("date", "2024-12-31").unwrap();
+    mapping.set("count", 100).unwrap();
 
     // Verify the values changed
     let new_date = mapping.get("date").expect("Should have date");
@@ -248,8 +248,8 @@ fn test_add_to_empty_flow_mapping() {
     assert_eq!(empty_map.keys().count(), 0, "Should be empty initially");
 
     // Add keys to the empty mapping
-    empty_map.set("a", 1);
-    empty_map.set("b", 2);
+    empty_map.set("a", 1).unwrap();
+    empty_map.set("b", 2).unwrap();
 
     // Verify keys were added
     assert_eq!(empty_map.keys().count(), 2, "Should have 2 keys");

--- a/tests/mutation_edge_cases_test.rs
+++ b/tests/mutation_edge_cases_test.rs
@@ -284,9 +284,9 @@ fn test_add_to_empty_flow_sequence() {
     assert_eq!(empty_seq.len(), 0, "Should be empty initially");
 
     // Add items to the empty sequence
-    empty_seq.push("first");
-    empty_seq.push("second");
-    empty_seq.push("third");
+    empty_seq.push("first").unwrap();
+    empty_seq.push("second").unwrap();
+    empty_seq.push("third").unwrap();
 
     // Verify items were added
     assert_eq!(empty_seq.len(), 3, "Should have 3 items");

--- a/tests/mutation_tests.rs
+++ b/tests/mutation_tests.rs
@@ -22,7 +22,7 @@ fn test_simple_value_replacement() {
 
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
-            mapping.set("key", "new_value");
+            mapping.set("key", "new_value").unwrap();
         }
     }
 
@@ -40,7 +40,7 @@ fn test_value_replacement_preserves_whitespace() {
 
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
-            mapping.set("key", "new_value");
+            mapping.set("key", "new_value").unwrap();
         }
     }
 
@@ -58,7 +58,7 @@ fn test_boolean_value_replacement() {
 
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
-            mapping.set("debug", false);
+            mapping.set("debug", false).unwrap();
         }
     }
 
@@ -81,7 +81,7 @@ fn test_nested_mapping_mutation() {
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             mapping.modify_mapping("database", |db| {
-                db.set("name", "prod_db");
+                db.set("name", "prod_db").unwrap();
             });
         }
     }
@@ -108,7 +108,7 @@ fn test_nested_mapping_add_new_key() {
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             mapping.modify_mapping("database", |db| {
-                db.set("password", "secret123");
+                db.set("password", "secret123").unwrap();
             });
         }
     }
@@ -136,9 +136,9 @@ debug: true"#;
 
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
-            mapping.set("host", "0.0.0.0");
-            mapping.set("port", 3000);
-            mapping.set("debug", false);
+            mapping.set("host", "0.0.0.0").unwrap();
+            mapping.set("port", 3000).unwrap();
+            mapping.set("debug", false).unwrap();
         }
     }
 
@@ -159,7 +159,7 @@ fn test_add_new_root_key() {
 
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
-            mapping.set("new_key", "new_value");
+            mapping.set("new_key", "new_value").unwrap();
         }
     }
 
@@ -186,8 +186,8 @@ server:
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             mapping.modify_mapping("server", |server| {
-                server.set("host", "0.0.0.0");
-                server.set("timeout", 30);
+                server.set("host", "0.0.0.0").unwrap();
+                server.set("timeout", 30).unwrap();
             });
         }
     }
@@ -221,9 +221,9 @@ fn test_nested_mapping_mutations_propagate() {
         if let Some(mapping) = doc.as_mapping() {
             // Get the nested database mapping and modify it
             if let Some(db) = mapping.get_mapping("database") {
-                db.set("name", "prod_db");
-                db.set("password", "secret123");
-                db.set("max_connections", 50);
+                db.set("name", "prod_db").unwrap();
+                db.set("password", "secret123").unwrap();
+                db.set("max_connections", 50).unwrap();
             }
         }
     }
@@ -254,8 +254,8 @@ fn test_deeply_nested_mutations() {
             if let Some(server) = root.get_mapping("server") {
                 if let Some(db) = server.get_mapping("database") {
                     if let Some(primary) = db.get_mapping("primary") {
-                        primary.set("host", "prod.example.com");
-                        primary.set("ssl", true);
+                        primary.set("host", "prod.example.com").unwrap();
+                        primary.set("ssl", true).unwrap();
                     }
                 }
             }

--- a/tests/test_explicit_key_mutations.rs
+++ b/tests/test_explicit_key_mutations.rs
@@ -31,7 +31,7 @@ fn test_explicit_key_mutations() {
     );
 
     // Change value1 to newvalue
-    mapping.set("key1", "newvalue");
+    mapping.set("key1", "newvalue").unwrap();
 
     // Verify mutation via API
     assert_eq!(
@@ -67,7 +67,7 @@ fn test_explicit_key_mutations() {
     );
 
     // Add new key
-    mapping2.set("newkey", "newvalue");
+    mapping2.set("newkey", "newvalue").unwrap();
 
     // Verify addition via API
     assert_eq!(mapping2.len(), 2);

--- a/tests/test_invalid_flow_block_mix.rs
+++ b/tests/test_invalid_flow_block_mix.rs
@@ -36,7 +36,7 @@ key1: value1"#;
         if let Some(mapping) = doc.as_mapping() {
             // Add a new key - since the mapping is {}, the new key is added there
             // The invalid content after {} is preserved in ERROR nodes
-            mapping.set("key2", "value2");
+            mapping.set("key2", "value2").unwrap();
         }
     }
 
@@ -65,7 +65,7 @@ version: 1.0"#;
             // which preserve "name: test\nversion: 1.0"
 
             // Add a key to the empty mapping
-            mapping.set("author", "John");
+            mapping.set("author", "John").unwrap();
 
             // The new key is added to {}, invalid content remains in ERROR nodes
             let expected = "---\n{}\nauthor: John\n\nname: test\nversion: 1.0";

--- a/tests/test_invalid_flow_block_mix.rs
+++ b/tests/test_invalid_flow_block_mix.rs
@@ -43,8 +43,7 @@ key1: value1"#;
     let result = yaml.to_string();
 
     // The parser preserves BOTH the new key and the original invalid content
-    // In flow-style context ({}), strings are quoted
-    assert_eq!(result, "---\n{}\nkey2: \"value2\"\n\nkey1: value1");
+    assert_eq!(result, "---\n{}\nkey2: value2\n\nkey1: value1");
 }
 
 #[test]
@@ -69,8 +68,7 @@ version: 1.0"#;
             mapping.set("author", "John");
 
             // The new key is added to {}, invalid content remains in ERROR nodes
-            // In flow-style context ({}), strings are quoted
-            let expected = "---\n{}\nauthor: \"John\"\n\nname: test\nversion: 1.0";
+            let expected = "---\n{}\nauthor: John\n\nname: test\nversion: 1.0";
             assert_eq!(yaml.to_string(), expected);
         }
     }

--- a/tests/test_set_with_field_order.rs
+++ b/tests/test_set_with_field_order.rs
@@ -12,7 +12,9 @@ description: A test app"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["name", "version", "description"];
-            mapping.set_with_field_order("version", 2.0, field_order);
+            mapping
+                .set_with_field_order("version", 2.0, field_order)
+                .unwrap();
         }
     }
 
@@ -33,7 +35,9 @@ description: A test app"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["name", "version", "description"];
-            mapping.set_with_field_order("version", 1.0, field_order);
+            mapping
+                .set_with_field_order("version", 1.0, field_order)
+                .unwrap();
         }
     }
 
@@ -54,7 +58,9 @@ description: A test app"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["name", "version", "description"];
-            mapping.set_with_field_order("name", "my-app", field_order);
+            mapping
+                .set_with_field_order("name", "my-app", field_order)
+                .unwrap();
         }
     }
 
@@ -75,7 +81,9 @@ version: 1.0"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["name", "version", "description"];
-            mapping.set_with_field_order("description", "A test app", field_order);
+            mapping
+                .set_with_field_order("description", "A test app", field_order)
+                .unwrap();
         }
     }
 
@@ -97,7 +105,9 @@ version: 1.0"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["name", "version", "description"];
-            mapping.set_with_field_order("author", "John Doe", field_order);
+            mapping
+                .set_with_field_order("author", "John Doe", field_order)
+                .unwrap();
         }
     }
 
@@ -122,8 +132,12 @@ author: John Doe
             let field_order = &["name", "version", "description", "author"];
 
             // Add multiple keys in different orders
-            mapping.set_with_field_order("description", "A test app", field_order);
-            mapping.set_with_field_order("name", "my-app", field_order);
+            mapping
+                .set_with_field_order("description", "A test app", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order("name", "my-app", field_order)
+                .unwrap();
         }
     }
 
@@ -146,7 +160,8 @@ author: John Doe
 
     if let Some(doc) = yaml.document() {
         let field_order = &["name", "version", "description", "author"];
-        doc.set_with_field_order("name", "my-app", field_order);
+        doc.set_with_field_order("name", "my-app", field_order)
+            .unwrap();
     }
 
     let result = yaml.to_string();
@@ -164,8 +179,10 @@ fn test_set_with_field_order_empty_document() {
 
     if let Some(doc) = yaml.document() {
         let field_order = &["name", "version", "description"];
-        doc.set_with_field_order("name", "my-app", field_order);
-        doc.set_with_field_order("version", 1.0, field_order);
+        doc.set_with_field_order("name", "my-app", field_order)
+            .unwrap();
+        doc.set_with_field_order("version", 1.0, field_order)
+            .unwrap();
     }
 
     let result = yaml.to_string();
@@ -185,9 +202,15 @@ e: value_e"#;
             let field_order = &["a", "b", "c", "d", "e"];
 
             // Insert fields that should come before existing ones
-            mapping.set_with_field_order("a", "value_a", field_order);
-            mapping.set_with_field_order("b", "value_b", field_order);
-            mapping.set_with_field_order("c", "value_c", field_order);
+            mapping
+                .set_with_field_order("a", "value_a", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order("b", "value_b", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order("c", "value_c", field_order)
+                .unwrap();
         }
     }
 
@@ -213,7 +236,9 @@ c: value_c"#;
             let field_order = &["a", "b", "c"];
 
             // Insert 'b' between 'a' and 'c'
-            mapping.set_with_field_order("b", "value_b", field_order);
+            mapping
+                .set_with_field_order("b", "value_b", field_order)
+                .unwrap();
         }
     }
 
@@ -238,7 +263,9 @@ c: value_c"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["a", "b", "c"];
-            mapping.set_with_field_order("a", "value_a", field_order);
+            mapping
+                .set_with_field_order("a", "value_a", field_order)
+                .unwrap();
         }
     }
 
@@ -261,8 +288,12 @@ c: value_c"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["a", "b", "c", "d"];
-            mapping.set_with_field_order("b", "value_b", field_order);
-            mapping.set_with_field_order("d", "value_d", field_order);
+            mapping
+                .set_with_field_order("b", "value_b", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order("d", "value_d", field_order)
+                .unwrap();
         }
     }
 
@@ -303,7 +334,9 @@ Contact: https://forum.example.com"#;
             ];
 
             // Add Name field which should be inserted at the very beginning
-            mapping.set_with_field_order("Name", "blah", field_order);
+            mapping
+                .set_with_field_order("Name", "blah", field_order)
+                .unwrap();
         }
     }
 
@@ -336,7 +369,9 @@ fn test_multiline_value_no_extra_newlines() {
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["multi", "next"];
-            mapping.set_with_field_order("next", "value", field_order);
+            mapping
+                .set_with_field_order("next", "value", field_order)
+                .unwrap();
         }
     }
 
@@ -376,33 +411,47 @@ fn test_lintian_brush_line_interrupted() {
             ];
 
             // Add multiple fields that should all come before Registry
-            mapping.set_with_field_order("Name", "tsne", field_order);
-            mapping.set_with_field_order(
-                "Contact",
-                "Justin Donaldson <jdonaldson@gmail.com>",
-                field_order,
-            );
-            mapping.set_with_field_order("Archive", "CRAN", field_order);
-            mapping.set_with_field_order(
-                "Bug-Database",
-                "https://github.com/jdonaldson/rtsne/issues",
-                field_order,
-            );
-            mapping.set_with_field_order(
-                "Bug-Submit",
-                "https://github.com/jdonaldson/rtsne/issues/new",
-                field_order,
-            );
-            mapping.set_with_field_order(
-                "Repository",
-                "https://github.com/jdonaldson/rtsne.git",
-                field_order,
-            );
-            mapping.set_with_field_order(
-                "Repository-Browse",
-                "https://github.com/jdonaldson/rtsne",
-                field_order,
-            );
+            mapping
+                .set_with_field_order("Name", "tsne", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order(
+                    "Contact",
+                    "Justin Donaldson <jdonaldson@gmail.com>",
+                    field_order,
+                )
+                .unwrap();
+            mapping
+                .set_with_field_order("Archive", "CRAN", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order(
+                    "Bug-Database",
+                    "https://github.com/jdonaldson/rtsne/issues",
+                    field_order,
+                )
+                .unwrap();
+            mapping
+                .set_with_field_order(
+                    "Bug-Submit",
+                    "https://github.com/jdonaldson/rtsne/issues/new",
+                    field_order,
+                )
+                .unwrap();
+            mapping
+                .set_with_field_order(
+                    "Repository",
+                    "https://github.com/jdonaldson/rtsne.git",
+                    field_order,
+                )
+                .unwrap();
+            mapping
+                .set_with_field_order(
+                    "Repository-Browse",
+                    "https://github.com/jdonaldson/rtsne",
+                    field_order,
+                )
+                .unwrap();
         }
     }
 
@@ -446,22 +495,30 @@ Repository-Browse: https://github.com/example/blah
                 "Security-Contact",
             ];
 
-            mapping.set_with_field_order("Name", "blah", field_order);
-            mapping.set_with_field_order(
-                "Bug-Database",
-                "https://github.com/example/blah/issues",
-                field_order,
-            );
-            mapping.set_with_field_order(
-                "Bug-Submit",
-                "https://github.com/example/blah/issues/new",
-                field_order,
-            );
-            mapping.set_with_field_order(
-                "Security-Contact",
-                "https://github.com/example/blah/tree/HEAD/SECURITY.md",
-                field_order,
-            );
+            mapping
+                .set_with_field_order("Name", "blah", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order(
+                    "Bug-Database",
+                    "https://github.com/example/blah/issues",
+                    field_order,
+                )
+                .unwrap();
+            mapping
+                .set_with_field_order(
+                    "Bug-Submit",
+                    "https://github.com/example/blah/issues/new",
+                    field_order,
+                )
+                .unwrap();
+            mapping
+                .set_with_field_order(
+                    "Security-Contact",
+                    "https://github.com/example/blah/tree/HEAD/SECURITY.md",
+                    field_order,
+                )
+                .unwrap();
         }
     }
 
@@ -493,7 +550,9 @@ version: 1.0
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["name", "author", "version", "description"];
-            mapping.set_with_field_order("author", "John Doe", field_order);
+            mapping
+                .set_with_field_order("author", "John Doe", field_order)
+                .unwrap();
         }
     }
 
@@ -522,7 +581,9 @@ version: 1.0"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["name", "author", "description", "version"];
-            mapping.set_with_field_order("author", "Jane Smith", field_order);
+            mapping
+                .set_with_field_order("author", "Jane Smith", field_order)
+                .unwrap();
         }
     }
 
@@ -549,7 +610,9 @@ version: 1.0"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["name", "name", "author", "version", "version"];
-            mapping.set_with_field_order("author", "Bob", field_order);
+            mapping
+                .set_with_field_order("author", "Bob", field_order)
+                .unwrap();
         }
     }
 
@@ -572,7 +635,9 @@ version: 1.0"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order: &[&str] = &[];
-            mapping.set_with_field_order("author", "Alice", field_order);
+            mapping
+                .set_with_field_order("author", "Alice", field_order)
+                .unwrap();
         }
     }
 
@@ -597,7 +662,9 @@ fn test_set_with_field_order_special_characters_in_keys() {
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["regular-key", "new-key", "key with spaces", "single-quoted"];
-            mapping.set_with_field_order("new-key", "new-value", field_order);
+            mapping
+                .set_with_field_order("new-key", "new-value", field_order)
+                .unwrap();
         }
     }
 
@@ -624,7 +691,9 @@ version: 1.0"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["name", "author", "config", "version"];
-            mapping.set_with_field_order("author", "Developer", field_order);
+            mapping
+                .set_with_field_order("author", "Developer", field_order)
+                .unwrap();
         }
     }
 
@@ -651,8 +720,12 @@ count: 42"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["name", "version", "count"];
-            mapping.set_with_field_order("version", 2.0, field_order);
-            mapping.set_with_field_order("count", 100, field_order);
+            mapping
+                .set_with_field_order("version", 2.0, field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order("count", 100, field_order)
+                .unwrap();
         }
     }
 
@@ -676,7 +749,9 @@ description: test"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["version"];
-            mapping.set_with_field_order("author", "Solo", field_order);
+            mapping
+                .set_with_field_order("author", "Solo", field_order)
+                .unwrap();
         }
     }
 
@@ -702,10 +777,18 @@ fn test_set_with_field_order_all_new_fields() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["name", "version", "author", "description"];
 
-            mapping.set_with_field_order("description", "A test app", field_order);
-            mapping.set_with_field_order("name", "test-app", field_order);
-            mapping.set_with_field_order("author", "Tester", field_order);
-            mapping.set_with_field_order("version", "0.1.0", field_order);
+            mapping
+                .set_with_field_order("description", "A test app", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order("name", "test-app", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order("author", "Tester", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order("version", "0.1.0", field_order)
+                .unwrap();
         }
     }
 
@@ -728,7 +811,9 @@ another: data"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["name", "author", "version"];
-            mapping.set_with_field_order("author", "Partial", field_order);
+            mapping
+                .set_with_field_order("author", "Partial", field_order)
+                .unwrap();
         }
     }
 
@@ -754,7 +839,9 @@ end: value"#;
                 "field1", "field2", "field3", "field4", "field5", "start", "middle", "field6",
                 "field7", "field8", "field9", "field10", "end", "field11", "field12",
             ];
-            mapping.set_with_field_order("middle", "inserted", field_order);
+            mapping
+                .set_with_field_order("middle", "inserted", field_order)
+                .unwrap();
         }
     }
 
@@ -777,7 +864,9 @@ version: 1.0"#;
     if let Some(doc) = yaml.document() {
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["名前", "作者", "version"];
-            mapping.set_with_field_order("作者", "山田太郎", field_order);
+            mapping
+                .set_with_field_order("作者", "山田太郎", field_order)
+                .unwrap();
         }
     }
 
@@ -801,10 +890,18 @@ field5: value5"#;
         if let Some(mapping) = doc.as_mapping() {
             let field_order = &["field1", "field2", "field3", "field4", "field5"];
 
-            mapping.set_with_field_order("field3", "value3", field_order);
-            mapping.set_with_field_order("field2", "value2", field_order);
-            mapping.set_with_field_order("field4", "value4", field_order);
-            mapping.set_with_field_order("field1", "updated1", field_order);
+            mapping
+                .set_with_field_order("field3", "value3", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order("field2", "value2", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order("field4", "value4", field_order)
+                .unwrap();
+            mapping
+                .set_with_field_order("field1", "updated1", field_order)
+                .unwrap();
         }
     }
 

--- a/tests/test_set_with_field_order.rs
+++ b/tests/test_set_with_field_order.rs
@@ -169,13 +169,7 @@ fn test_set_with_field_order_empty_document() {
     }
 
     let result = yaml.to_string();
-    // In flow-style context ({}), strings are quoted
-    let expected = r#"---
-{}
-name: "my-app"
-version: 1.0
-"#;
-    assert_eq!(result, expected);
+    assert_eq!(result, "---\n{}\nname: my-app\nversion: 1.0\n");
 }
 
 #[test]
@@ -718,13 +712,7 @@ fn test_set_with_field_order_all_new_fields() {
     let result = yaml.to_string();
     assert_eq!(
         result,
-        r#"---
-{}
-name: "test-app"
-version: "0.1.0"
-author: "Tester"
-description: "A test app"
-"#
+        "---\n{}\nname: test-app\nversion: 0.1.0\nauthor: Tester\ndescription: A test app\n"
     );
 }
 


### PR DESCRIPTION
- Add flow-style sequence support to `Sequence::push` (insert before `]`, with `, ` separator)
- Add flow-context-aware scalar quoting via `string_in_context()` so flow indicators are properly quoted
- Change all mutation methods (`set`, `insert_*`, `move_*`, `push`) to return `Result<(), YamlError>`, rejecting invalid operations like inserting block-style content into flow collections
