### PR TITLE
Cover scalar, value, and path logic missed by mutation testing

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -998,6 +998,23 @@ config:
     }
 
     #[test]
+    fn test_mapping_remove_path_single_segment() {
+        use crate::yaml::Document;
+        use std::str::FromStr;
+
+        let yaml = Document::from_str("a: 1\nb: 2\n").unwrap();
+        let mapping = yaml.as_mapping().unwrap();
+
+        // A single-segment path removes the key directly from the mapping.
+        assert!(mapping.remove_path("a"));
+        assert!(mapping.get_path("a").is_none());
+        assert!(mapping.get_path("b").is_some());
+
+        // Removing a missing single-segment key returns false.
+        assert!(!mapping.remove_path("missing"));
+    }
+
+    #[test]
     fn test_set_path_preserves_formatting() {
         use crate::yaml::Document;
         use std::str::FromStr;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -2059,4 +2059,220 @@ mod tests {
         assert_eq!(legacy_octal_scalar.scalar_type(), ScalarType::Integer);
         assert_eq!(legacy_octal_scalar.value(), "0755");
     }
+
+    #[test]
+    fn test_unix_timestamp_bounds() {
+        // Unix epoch boundary: 0 is rejected, 1 accepted, and the upper bound
+        // (2100-01-01) is exclusive.
+        assert!(!ScalarValue::is_valid_timestamp_static("0"));
+        assert!(ScalarValue::is_valid_timestamp_static("1"));
+        assert!(ScalarValue::is_valid_timestamp_static("4102444799"));
+        assert!(!ScalarValue::is_valid_timestamp_static("4102444800"));
+
+        // The instance method delegates to the static one.
+        let s = ScalarValue::string("x");
+        assert!(s.is_valid_timestamp("1"));
+        assert!(!s.is_valid_timestamp("0"));
+    }
+
+    #[test]
+    fn test_iso8601_time_component_bounds() {
+        // Hour/minute/second upper bounds: 23:59:59 is valid, anything past is not.
+        assert!(ScalarValue::matches_iso8601_pattern("2023-01-01T23:59:59"));
+        assert!(!ScalarValue::matches_iso8601_pattern("2023-01-01T24:00:00"));
+        assert!(!ScalarValue::matches_iso8601_pattern("2023-01-01T10:60:00"));
+        assert!(!ScalarValue::matches_iso8601_pattern("2023-01-01T10:30:60"));
+
+        // Day bounds: 31 is valid, 0 and 32 are not.
+        assert!(ScalarValue::matches_iso8601_pattern("2023-01-31"));
+        assert!(!ScalarValue::matches_iso8601_pattern("2023-01-00"));
+        assert!(!ScalarValue::matches_iso8601_pattern("2023-01-32"));
+
+        // A malformed time separator falls through to invalid.
+        assert!(!ScalarValue::matches_iso8601_pattern("2023-01-01X10:30:45"));
+        // Time present but seconds field non-numeric.
+        assert!(!ScalarValue::matches_iso8601_pattern("2023-01-01T10:30:xx"));
+
+        // The two date separators must each be '-'. A non-dash in either
+        // position must reject even though the digit groups parse as valid
+        // month/day. This pins the separator conjuncts in the format check.
+        assert!(!ScalarValue::matches_iso8601_pattern("2023X12-25"));
+        assert!(!ScalarValue::matches_iso8601_pattern("2023-12X25"));
+    }
+
+    #[test]
+    #[cfg(feature = "base64")]
+    fn test_base64_padding_bounds() {
+        // Exactly two padding characters is the maximum allowed and must pass.
+        assert!(ScalarValue::looks_like_base64("QQ==")); // "A"
+                                                         // One padding character.
+        assert!(ScalarValue::looks_like_base64("SGVsbG8=")); // "Hello"
+                                                             // Padding in the middle is rejected even with a valid count.
+        assert!(!ScalarValue::looks_like_base64("QQ=Q"));
+        // Length not a multiple of 4.
+        assert!(!ScalarValue::looks_like_base64("QQQ"));
+    }
+
+    #[test]
+    fn test_coerce_to_null() {
+        // Only the recognized null spellings coerce to Null.
+        let s = ScalarValue::string("null");
+        assert_eq!(
+            s.coerce_to_type(ScalarType::Null).map(|v| v.scalar_type()),
+            Some(ScalarType::Null)
+        );
+        assert!(ScalarValue::string("~")
+            .coerce_to_type(ScalarType::Null)
+            .is_some());
+        assert!(ScalarValue::string("")
+            .coerce_to_type(ScalarType::Null)
+            .is_some());
+        assert!(ScalarValue::string("notnull")
+            .coerce_to_type(ScalarType::Null)
+            .is_none());
+    }
+
+    #[test]
+    fn test_parse_escape_single_quote() {
+        // The \' escape decodes to a bare single quote.
+        assert_eq!(ScalarValue::parse_escape_sequences("a\\'b"), "a'b");
+    }
+
+    #[test]
+    fn test_parse_preserves_string_style() {
+        // The String arm of parse() runs detect_style; a plain word stays Plain.
+        let plain = ScalarValue::parse("hello");
+        assert_eq!(plain.scalar_type(), ScalarType::String);
+        assert_eq!(plain.style, ScalarStyle::Plain);
+
+        // A multi-line string is given Literal style by detect_style, which only
+        // runs in the String arm of parse().
+        let multiline = ScalarValue::parse("multi line\nvalue");
+        assert_eq!(multiline.scalar_type(), ScalarType::String);
+        assert_eq!(multiline.style, ScalarStyle::Literal);
+    }
+
+    #[test]
+    fn test_from_scalar_type_and_style() {
+        use crate::yaml::Document;
+        use rowan::ast::AstNode;
+        use std::str::FromStr;
+
+        // NULL token maps to Null type.
+        let doc = Document::from_str("k: null\n").unwrap();
+        let mapping = doc.as_mapping().unwrap();
+        let null_node = mapping.get("k").unwrap();
+        let null_scalar = crate::yaml::Scalar::cast(null_node.syntax().clone()).unwrap();
+        let sv = ScalarValue::from_scalar(&null_scalar);
+        assert_eq!(sv.scalar_type(), ScalarType::Null);
+        assert_eq!(sv.style, ScalarStyle::Plain);
+
+        // STRING token in double quotes maps to String type, DoubleQuoted style.
+        let doc = Document::from_str("k: \"hi\"\n").unwrap();
+        let node = doc.as_mapping().unwrap().get("k").unwrap();
+        let scalar = crate::yaml::Scalar::cast(node.syntax().clone()).unwrap();
+        let sv = ScalarValue::from_scalar(&scalar);
+        assert_eq!(sv.scalar_type(), ScalarType::String);
+        assert_eq!(sv.style, ScalarStyle::DoubleQuoted);
+
+        // Single quoted string keeps SingleQuoted style.
+        let doc = Document::from_str("k: 'hi'\n").unwrap();
+        let node = doc.as_mapping().unwrap().get("k").unwrap();
+        let scalar = crate::yaml::Scalar::cast(node.syntax().clone()).unwrap();
+        let sv = ScalarValue::from_scalar(&scalar);
+        assert_eq!(sv.style, ScalarStyle::SingleQuoted);
+    }
+
+    #[test]
+    fn test_needs_quoting_special_chars() {
+        // Leading-character based quoting and special embedded characters, plus
+        // each boolean/null keyword spelling (so dropping any one keyword arm is
+        // detected). Single quotes are preferred unless the value already
+        // contains one, in which case double quotes are used.
+        let cases = [
+            ("&anchor", "'&anchor'"),
+            ("*alias", "'*alias'"),
+            ("!tag", "'!tag'"),
+            ("a|b", "'a|b'"),
+            ("it's", "\"it's\""),
+            ("a\"b", "'a\"b'"),
+            ("50%", "'50%'"),
+            ("on", "'on'"),
+            ("off", "'off'"),
+            ("On", "'On'"),
+            ("OFF", "'OFF'"),
+            ("yes", "'yes'"),
+            ("no", "'no'"),
+            ("true", "'true'"),
+            ("false", "'false'"),
+            ("null", "'null'"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(ScalarValue::string(input).to_yaml_string(), expected);
+        }
+        // A plain word that needs no quoting round-trips unchanged.
+        assert_eq!(ScalarValue::string("plain").to_yaml_string(), "plain");
+    }
+
+    #[test]
+    fn test_literal_and_folded_nonempty() {
+        // Literal and folded styles render the block indicator on its own line
+        // followed by the content indented by two spaces.
+        let s = ScalarValue::with_style("line one\nline two", ScalarStyle::Literal);
+        assert_eq!(s.to_yaml_string(), "|\n  line one\n  line two");
+
+        let s = ScalarValue::with_style("line one\nline two", ScalarStyle::Folded);
+        assert_eq!(s.to_yaml_string(), ">\n  line one\n  line two");
+    }
+
+    #[test]
+    fn test_display_matches_yaml_string() {
+        let s = ScalarValue::string("true");
+        assert_eq!(format!("{}", s), s.to_yaml_string());
+        assert_eq!(format!("{}", s), "'true'");
+    }
+
+    #[test]
+    fn test_as_yaml_token_kind_per_type() {
+        use crate::lex::SyntaxKind;
+        use rowan::ast::AstNode;
+
+        let cases = [
+            (ScalarValue::parse("42"), SyntaxKind::INT),
+            (ScalarValue::parse("3.14"), SyntaxKind::FLOAT),
+            (ScalarValue::parse("true"), SyntaxKind::BOOL),
+            (ScalarValue::parse("null"), SyntaxKind::NULL),
+            (ScalarValue::string("hello"), SyntaxKind::STRING),
+        ];
+        for (value, expected) in cases {
+            let mut builder = rowan::GreenNodeBuilder::new();
+            crate::AsYaml::build_content(&value, &mut builder, 0, false);
+            let green = builder.finish();
+            let node = rowan::SyntaxNode::<crate::yaml::Lang>::new_root(green);
+            let scalar = crate::yaml::Scalar::cast(node).unwrap();
+            let kind = scalar
+                .syntax()
+                .children_with_tokens()
+                .filter_map(|c| c.into_token())
+                .next()
+                .unwrap()
+                .kind();
+            assert_eq!(kind, expected, "value {:?}", value.value());
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "regex")]
+    fn test_as_regex_type_gated() {
+        // as_regex only compiles when the scalar is tagged as a regex.
+        let re = ScalarValue::regex(r"\d+");
+        assert!(re.as_regex().is_some());
+
+        let not_re = ScalarValue::string(r"\d+");
+        assert!(not_re.as_regex().is_none());
+
+        // try_as_regex ignores the type and compiles the value directly.
+        assert!(not_re.try_as_regex().is_ok());
+        assert!(ScalarValue::string("(").try_as_regex().is_err());
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -635,6 +635,250 @@ where
 mod tests {
     use super::*;
 
+    fn render_as_yaml<T: crate::AsYaml>(v: &T) -> String {
+        let mut builder = rowan::GreenNodeBuilder::new();
+        v.build_content(&mut builder, 0, false);
+        let green = builder.finish();
+        let node = rowan::SyntaxNode::<crate::yaml::Lang>::new_root(green);
+        node.text().to_string()
+    }
+
+    fn scalar_token_kind(v: &YamlValue) -> crate::lex::SyntaxKind {
+        use rowan::ast::AstNode;
+        let mut builder = rowan::GreenNodeBuilder::new();
+        crate::AsYaml::build_content(v, &mut builder, 0, false);
+        let green = builder.finish();
+        let node = rowan::SyntaxNode::<crate::yaml::Lang>::new_root(green);
+        let scalar = crate::yaml::Scalar::cast(node).expect("scalar node");
+        scalar
+            .syntax()
+            .children_with_tokens()
+            .filter_map(|c| c.into_token())
+            .next()
+            .expect("token")
+            .kind()
+    }
+
+    #[test]
+    fn test_scalar_build_content_token_kind() {
+        use crate::lex::SyntaxKind;
+        assert_eq!(
+            scalar_token_kind(&YamlValue::from("hello")),
+            SyntaxKind::STRING
+        );
+        assert_eq!(scalar_token_kind(&YamlValue::from(42)), SyntaxKind::INT);
+        assert_eq!(scalar_token_kind(&YamlValue::from(1.5)), SyntaxKind::FLOAT);
+        assert_eq!(
+            scalar_token_kind(&YamlValue::Scalar(ScalarValue::string("true"))),
+            SyntaxKind::BOOL
+        );
+        assert_eq!(
+            scalar_token_kind(&YamlValue::Scalar(ScalarValue::string("false"))),
+            SyntaxKind::BOOL
+        );
+        assert_eq!(
+            scalar_token_kind(&YamlValue::Scalar(ScalarValue::string("null"))),
+            SyntaxKind::NULL
+        );
+    }
+
+    #[test]
+    fn test_as_yaml_build_content_tagged_and_nested() {
+        // Tagged collections render the tag, a newline, then content indented by
+        // two spaces (indent + 2). A wrong arithmetic op would drop the indent.
+        let omap = YamlValue::from_ordered_mapping(vec![
+            ("a".to_string(), YamlValue::from("1")),
+            ("b".to_string(), YamlValue::from("2")),
+        ]);
+        assert_eq!(render_as_yaml(&omap), "!!omap\n  - a: 1\n  - b: 2\n");
+
+        let pairs = YamlValue::from_pairs(vec![("a".to_string(), YamlValue::from("1"))]);
+        assert_eq!(render_as_yaml(&pairs), "!!pairs\n  - a: 1\n");
+
+        let set = YamlValue::from_set(BTreeSet::from(["a".to_string(), "b".to_string()]));
+        assert_eq!(render_as_yaml(&set), "!!set\n  a: null\n  b: null\n");
+
+        // A mapping whose value is a multi-entry mapping. The inner mapping's
+        // own entry separators are indented by the indent passed down
+        // (BTreeMap::build_content indent + 2), so a wrong op shows up on the
+        // second inner key.
+        let mut inner = BTreeMap::new();
+        inner.insert("x".to_string(), YamlValue::from("1"));
+        inner.insert("y".to_string(), YamlValue::from("2"));
+        let mut outer = BTreeMap::new();
+        outer.insert("o".to_string(), YamlValue::Mapping(inner));
+        assert_eq!(render_as_yaml(&outer), "o:\n  x: 1\n  y: 2\n");
+
+        // Pairs with two entries: the indent passed into the nested sequence
+        // shows on the second item's "  - " separator (Pairs branch indent + 2).
+        let pairs2 = YamlValue::from_pairs(vec![
+            ("a".to_string(), YamlValue::from("1")),
+            ("b".to_string(), YamlValue::from("2")),
+        ]);
+        assert_eq!(render_as_yaml(&pairs2), "!!pairs\n  - a: 1\n  - b: 2\n");
+
+        // A sequence nested inside a sequence (&[]::build_content indent + 2).
+        let seq = vec![YamlValue::Sequence(vec![YamlValue::from("a")])];
+        assert_eq!(render_as_yaml(&seq), "- - a\n");
+
+        // A sequence whose single item is a multi-entry mapping: the indent
+        // handed to that item (&[]::build_content indent + 2) shows on the
+        // second mapping key.
+        let mut item = BTreeMap::new();
+        item.insert("x".to_string(), YamlValue::from("1"));
+        item.insert("y".to_string(), YamlValue::from("2"));
+        let seq_of_map = vec![YamlValue::Mapping(item)];
+        assert_eq!(render_as_yaml(&seq_of_map), "- x: 1\n  y: 2\n");
+    }
+
+    #[test]
+    fn test_as_yaml_build_content() {
+        use crate::AsYaml;
+
+        // Vec<YamlValue> and &[YamlValue] render as a block sequence.
+        let seq = vec![YamlValue::from("a"), YamlValue::from("b")];
+        assert_eq!(render_as_yaml(&seq), "- a\n- b\n");
+        assert_eq!(render_as_yaml(&seq.as_slice()), "- a\n- b\n");
+
+        // BTreeMap renders as a block mapping (keys sorted).
+        let mut m = BTreeMap::new();
+        m.insert("k".to_string(), YamlValue::from("v"));
+        m.insert("j".to_string(), YamlValue::from("w"));
+        assert_eq!(render_as_yaml(&m), "j: w\nk: v\n");
+
+        // Empty collections render in flow style.
+        let empty_seq: Vec<YamlValue> = vec![];
+        assert_eq!(render_as_yaml(&empty_seq), "[]");
+        let empty_map: BTreeMap<String, YamlValue> = BTreeMap::new();
+        assert_eq!(render_as_yaml(&empty_map), "{}");
+
+        // A mapping whose value is a non-scalar gets a newline and deeper indent.
+        let mut m2 = BTreeMap::new();
+        m2.insert(
+            "list".to_string(),
+            YamlValue::Sequence(vec![YamlValue::from("a")]),
+        );
+        assert_eq!(render_as_yaml(&m2), "list:\n  - a\n");
+
+        // YamlValue delegates to the right impl per variant.
+        assert_eq!(
+            render_as_yaml(&YamlValue::Sequence(seq.clone())),
+            "- a\n- b\n"
+        );
+        assert_eq!(
+            render_as_yaml(&YamlValue::Mapping(m.clone())),
+            "j: w\nk: v\n"
+        );
+        assert_eq!(render_as_yaml(&YamlValue::from("scalar")), "scalar");
+
+        // is_inline: empty collections are inline, non-empty block collections
+        // are not. Scalars are always inline.
+        assert!(!AsYaml::is_inline(&seq));
+        assert!(AsYaml::is_inline(&empty_seq));
+        assert!(!AsYaml::is_inline(&m));
+        assert!(AsYaml::is_inline(&empty_map));
+        assert!(!AsYaml::is_inline(&seq.as_slice()));
+        assert!(AsYaml::is_inline(&empty_seq.as_slice()));
+        assert!(AsYaml::is_inline(&YamlValue::from("x")));
+        assert!(!AsYaml::is_inline(&YamlValue::Sequence(seq)));
+        assert!(AsYaml::is_inline(&YamlValue::sequence()));
+        assert!(!AsYaml::is_inline(&YamlValue::Mapping(m)));
+        assert!(AsYaml::is_inline(&YamlValue::mapping()));
+    }
+
+    #[test]
+    fn test_parse_raw_variants() {
+        // parse_raw goes through YamlValue::cast, so each YAML shape must map to
+        // the corresponding variant.
+        assert!(YamlValue::parse_raw("hello").is_scalar());
+
+        let seq = YamlValue::parse_raw("- a\n- b\n");
+        assert_eq!(
+            seq.as_sequence(),
+            Some([YamlValue::from("a"), YamlValue::from("b")].as_slice())
+        );
+
+        let map = YamlValue::parse_raw("k: v\n");
+        assert_eq!(map.as_mapping().map(|m| m.len()), Some(1));
+
+        let set = YamlValue::parse_raw("!!set\n  a: ~\n  b: ~\n");
+        assert_eq!(
+            set.as_set(),
+            Some(&BTreeSet::from(["a".to_string(), "b".to_string()]))
+        );
+
+        let omap = YamlValue::parse_raw("!!omap\n  - a: 1\n  - b: 2\n");
+        assert_eq!(
+            omap.as_ordered_mapping(),
+            Some(
+                [
+                    ("a".to_string(), YamlValue::from(1)),
+                    ("b".to_string(), YamlValue::from(2)),
+                ]
+                .as_slice()
+            )
+        );
+
+        let pairs = YamlValue::parse_raw("!!pairs\n  - a: 1\n  - a: 2\n");
+        assert_eq!(
+            pairs.as_pairs(),
+            Some(
+                [
+                    ("a".to_string(), YamlValue::from(1)),
+                    ("a".to_string(), YamlValue::from(2)),
+                ]
+                .as_slice()
+            )
+        );
+    }
+
+    #[test]
+    fn test_display_matches_to_yaml_string() {
+        let map = {
+            let mut m = BTreeMap::new();
+            m.insert("name".to_string(), YamlValue::from("app"));
+            YamlValue::Mapping(m)
+        };
+        assert_eq!(format!("{}", map), map.to_yaml_string(0));
+        assert_eq!(format!("{}", map), "name: app");
+
+        let scalar = YamlValue::from("hello");
+        assert_eq!(format!("{}", scalar), "hello");
+    }
+
+    #[test]
+    fn test_to_yaml_string_nested_indentation() {
+        // Sequence holding a non-scalar item: nested mapping is indented by
+        // indent + 4 relative to the dash.
+        let mut inner = BTreeMap::new();
+        inner.insert("h".to_string(), YamlValue::from("x"));
+        let seq = YamlValue::Sequence(vec![YamlValue::Mapping(inner)]);
+        assert_eq!(seq.to_yaml_string(0), "  - \n    h: x");
+
+        // Mapping holding a non-scalar value: nested sequence is rendered at
+        // indent + 2.
+        let mut m = BTreeMap::new();
+        m.insert(
+            "k".to_string(),
+            YamlValue::Sequence(vec![YamlValue::from("a")]),
+        );
+        assert_eq!(YamlValue::Mapping(m).to_yaml_string(0), "k: \n    - a");
+
+        // Ordered mapping with a non-scalar value: nested mapping at indent + 4.
+        let mut inner2 = BTreeMap::new();
+        inner2.insert("x".to_string(), YamlValue::from("y"));
+        let omap =
+            YamlValue::from_ordered_mapping(vec![("a".to_string(), YamlValue::Mapping(inner2))]);
+        assert_eq!(omap.to_yaml_string(0), "!!omap\n  - a: \n    x: y");
+
+        // Pairs with a non-scalar value: nested sequence at indent + 4.
+        let pairs = YamlValue::from_pairs(vec![(
+            "a".to_string(),
+            YamlValue::Sequence(vec![YamlValue::from("z")]),
+        )]);
+        assert_eq!(pairs.to_yaml_string(0), "!!pairs\n  - a: \n      - z");
+    }
+
     #[test]
     fn test_scalar_value() {
         let val = YamlValue::from("hello");
@@ -754,6 +998,93 @@ mod tests {
         // Empty pairs
         let val = YamlValue::pairs();
         assert_eq!(val.to_yaml_string(0), "!!pairs []");
+    }
+
+    #[test]
+    fn test_predicates_and_accessors() {
+        let scalar = YamlValue::from("s");
+        let seq = YamlValue::Sequence(vec![YamlValue::from("a")]);
+        let map = {
+            let mut m = BTreeMap::new();
+            m.insert("k".to_string(), YamlValue::from("v"));
+            YamlValue::Mapping(m)
+        };
+        let set = YamlValue::from_set(BTreeSet::from(["x".to_string()]));
+        let omap = YamlValue::from_ordered_mapping(vec![("a".to_string(), YamlValue::from("b"))]);
+        let pairs = YamlValue::from_pairs(vec![("a".to_string(), YamlValue::from("b"))]);
+
+        // Each predicate is true only for its own variant.
+        assert!(scalar.is_scalar());
+        assert!(!seq.is_scalar());
+
+        assert!(seq.is_sequence());
+        assert!(!scalar.is_sequence());
+
+        assert!(map.is_mapping());
+        assert!(!seq.is_mapping());
+
+        assert!(set.is_set());
+        assert!(!map.is_set());
+
+        assert!(omap.is_ordered_mapping());
+        assert!(!map.is_ordered_mapping());
+
+        assert!(pairs.is_pairs());
+        assert!(!omap.is_pairs());
+
+        // Accessors return Some only for the matching variant, None otherwise.
+        assert!(scalar.as_scalar().is_some());
+        assert!(seq.as_scalar().is_none());
+
+        assert_eq!(seq.as_sequence(), Some([YamlValue::from("a")].as_slice()));
+        assert_eq!(scalar.as_sequence(), None);
+
+        assert_eq!(map.as_mapping().map(|m| m.len()), Some(1));
+        assert_eq!(scalar.as_mapping(), None);
+
+        assert_eq!(set.as_set().map(|s| s.len()), Some(1));
+        assert_eq!(map.as_set(), None);
+
+        assert_eq!(omap.as_ordered_mapping().map(|p| p.len()), Some(1));
+        assert_eq!(map.as_ordered_mapping(), None);
+
+        assert_eq!(pairs.as_pairs().map(|p| p.len()), Some(1));
+        assert_eq!(omap.as_pairs(), None);
+    }
+
+    #[test]
+    fn test_accessors_mut() {
+        let mut seq = YamlValue::Sequence(vec![YamlValue::from("a")]);
+        seq.as_sequence_mut().unwrap().push(YamlValue::from("b"));
+        assert_eq!(seq.as_sequence().map(|s| s.len()), Some(2));
+        assert!(YamlValue::from("x").as_sequence_mut().is_none());
+
+        let mut map = YamlValue::mapping();
+        map.as_mapping_mut()
+            .unwrap()
+            .insert("k".to_string(), YamlValue::from("v"));
+        assert_eq!(map.as_mapping().map(|m| m.len()), Some(1));
+        assert!(YamlValue::from("x").as_mapping_mut().is_none());
+
+        let mut set = YamlValue::set();
+        set.as_set_mut().unwrap().insert("a".to_string());
+        assert_eq!(set.as_set().map(|s| s.len()), Some(1));
+        assert!(YamlValue::from("x").as_set_mut().is_none());
+
+        let mut omap = YamlValue::ordered_mapping();
+        omap.as_ordered_mapping_mut()
+            .unwrap()
+            .push(("a".to_string(), YamlValue::from("b")));
+        assert_eq!(omap.as_ordered_mapping().map(|p| p.len()), Some(1));
+        assert!(YamlValue::from("x").as_ordered_mapping_mut().is_none());
+
+        let mut pairs = YamlValue::pairs();
+        pairs
+            .as_pairs_mut()
+            .unwrap()
+            .push(("a".to_string(), YamlValue::from("b")));
+        assert_eq!(pairs.as_pairs().map(|p| p.len()), Some(1));
+        assert!(YamlValue::from("x").as_pairs_mut().is_none());
     }
 
     #[test]


### PR DESCRIPTION
Add tests pinning down boundary conditions and accessor behaviour that cargo-mutants flagged as untested: scalar type detection and timestamp validation bounds, base64 padding, escape sequences, YamlValue accessors and AsYaml rendering indentation, and single-segment mapping path removal.