### PR TITLE
Fix parsing bug with a non-intended sequence containing a mapping

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -1630,11 +1630,11 @@ impl Parser {
             // Start SEQUENCE_ENTRY node to wrap the entire item
             self.builder.start_node(SyntaxKind::SEQUENCE_ENTRY.into());
 
-            // Record the dash's line indentation for the item value parsing
-            let item_indent = self.current_line_indent;
-
             self.bump(); // consume dash
             self.skip_whitespace();
+
+            // Record the dash's line indentation for the item value parsing
+            let item_indent = self.current_line_indent;
 
             if self.current().is_some() && self.current() != Some(SyntaxKind::NEWLINE) {
                 // Use item's line indent so nested mappings parse at the right level
@@ -2796,6 +2796,9 @@ impl Parser {
                 SyntaxKind::NEWLINE => {
                     // Reset to 0 until we see the next INDENT
                     self.current_line_indent = 0;
+                }
+                SyntaxKind::DASH => {
+                    self.current_line_indent += text.len();
                 }
                 _ => {}
             }

--- a/tests/parsing_bugs.rs
+++ b/tests/parsing_bugs.rs
@@ -658,3 +658,36 @@ fn test_complex_key_mapping() {
     let parsed = YamlFile::from_str(yaml).expect("Failed to parse complex key mapping");
     assert!(parsed.document().is_some());
 }
+
+#[test]
+fn test_sequence_without_indentation_containing_mapping_followed_by_mapping() {
+    // Test a non-indented sequence with mapping value doesn't swallow up following mapping
+    let yaml = r#"
+items:
+- key: value1
+toplevel1: value2
+toplevel2: value3
+"#;
+
+    let parsed = YamlFile::from_str(yaml).expect("Failed to parse YAML");
+    let doc = parsed.document().expect("Should have a document");
+    let mapping = doc.as_mapping().expect("Root should be a mapping");
+
+    assert_eq!(mapping.keys().count(), 3, "Should have 3 top-level entries");
+
+    // Check the sequence has a single item
+    let items = mapping
+        .get("items")
+        .and_then(|node| node.as_sequence().cloned())
+        .expect("items should be a sequence");
+    assert_eq!(items.len(), 1, "Should have 1 item in sequence");
+
+    // Check the mapping in the sequence has a single item
+    let nested_mapping = items.pop().expect("1 item");
+    let nested_mapping = nested_mapping.as_mapping().expect("nested mapping");
+    assert_eq!(
+        nested_mapping.keys().count(),
+        1,
+        "Should have 1 nested entry"
+    );
+}


### PR DESCRIPTION
Fixes #27.

``` yaml
items:
- key: value1
toplevel1: value2
toplevel2: value3
```

parses as:

``` yaml
items:
  - key: value1
    toplevel1: value2
    toplevel2: value3
```

when you would expect it to parse as:

``` yaml
items:
  - key: value1
toplevel1: value2
toplevel2: value3
```

This fixes the issue by treating `-` as increasing the base indent. This approach seems to make sense to me, and it passes all the other tests, but I don't know the code as well as you, so I would understand if you want to take a different approach.

I'm happy to make any changes, or please feel free to take this code under the Apache-2.0 licence and adapt it yourself if that's easier than doing a PR review.

I'm not sure if it matters to you, but LLMs were not used in any part of diagnosing or authoring this change.