### PR TITLE
Fix parsing bug when sequence value is preceded by a comment

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -2736,13 +2736,9 @@ impl Parser {
                 }
                 // If no indented content follows the comment, has_value stays false → implicit null
             } else if self.current() == Some(SyntaxKind::NEWLINE) {
-                // Check if next line is indented (nested content) or starts with a sequence
-                self.bump(); // consume newline
-                if self.current() == Some(SyntaxKind::INDENT) {
-                    let indent_level = self.tokens.last().map(|(_, text)| text.len()).unwrap_or(0);
-                    self.bump(); // consume indent
-                                 // Parse the indented content as the value, tracking indent level
-                    self.parse_value_with_base_indent(indent_level);
+                self.skip_ws_and_newlines();
+                if self.current_line_indent != 0 {
+                    self.parse_value_with_base_indent(self.current_line_indent);
                     has_value = true;
                 } else if self.current() == Some(SyntaxKind::DASH) {
                     // Zero-indented sequence (same indentation as key)

--- a/tests/parsing_bugs.rs
+++ b/tests/parsing_bugs.rs
@@ -691,3 +691,92 @@ toplevel2: value3
         "Should have 1 nested entry"
     );
 }
+
+#[test]
+fn test_sequence_without_indentation_starting_with_comment() {
+    let yaml = r#"
+items:
+# comment
+- value1
+"#;
+    let parsed = YamlFile::from_str(yaml).expect("Failed to parse YAML");
+    let doc = parsed.document().expect("Should have a document");
+    let mapping = doc.as_mapping().expect("Root should be a mapping");
+
+    assert_eq!(mapping.keys().count(), 1, "Should have 1 top-level entry");
+
+    // Check the sequence has a single item
+    let items = mapping
+        .get("items")
+        .and_then(|node| node.as_sequence().cloned())
+        .expect("items should be a sequence");
+    assert_eq!(items.len(), 1, "Should have 1 item in sequence");
+}
+
+#[test]
+fn test_sequence_without_indentation_starting_with_indented_comment() {
+    let yaml = r#"
+items:
+  # comment
+- value1
+"#;
+    let parsed = YamlFile::from_str(yaml).expect("Failed to parse YAML");
+    dbg!(&parsed);
+    let doc = parsed.document().expect("Should have a document");
+    let mapping = doc.as_mapping().expect("Root should be a mapping");
+
+    assert_eq!(mapping.keys().count(), 1, "Should have 1 top-level entry");
+
+    // Check the sequence has a single item
+    let items = mapping
+        .get("items")
+        .and_then(|node| node.as_sequence().cloned())
+        .expect("items should be a sequence");
+    assert_eq!(items.len(), 1, "Should have 1 item in sequence");
+}
+
+#[test]
+fn test_sequence_without_indentation_starting_with_newline() {
+    let yaml = r#"
+items:
+
+- value1
+"#;
+    let parsed = YamlFile::from_str(yaml).expect("Failed to parse YAML");
+    let doc = parsed.document().expect("Should have a document");
+    let mapping = doc.as_mapping().expect("Root should be a mapping");
+
+    assert_eq!(mapping.keys().count(), 1, "Should have 1 top-level entry");
+
+    // Check the sequence has a single item
+    let items = mapping
+        .get("items")
+        .and_then(|node| node.as_sequence().cloned())
+        .expect("items should be a sequence");
+    assert_eq!(items.len(), 1, "Should have 1 item in sequence");
+}
+
+#[test]
+fn test_sequence_without_indentation_starting_with_newline_and_comment() {
+    let yaml = r#"
+items:
+
+# comment
+
+# comment
+
+- value1
+"#;
+    let parsed = YamlFile::from_str(yaml).expect("Failed to parse YAML");
+    let doc = parsed.document().expect("Should have a document");
+    let mapping = doc.as_mapping().expect("Root should be a mapping");
+
+    assert_eq!(mapping.keys().count(), 1, "Should have 1 top-level entry");
+
+    // Check the sequence has a single item
+    let items = mapping
+        .get("items")
+        .and_then(|node| node.as_sequence().cloned())
+        .expect("items should be a sequence");
+    assert_eq!(items.len(), 1, "Should have 1 item in sequence");
+}

--- a/tests/parsing_bugs.rs
+++ b/tests/parsing_bugs.rs
@@ -721,7 +721,6 @@ items:
 - value1
 "#;
     let parsed = YamlFile::from_str(yaml).expect("Failed to parse YAML");
-    dbg!(&parsed);
     let doc = parsed.document().expect("Should have a document");
     let mapping = doc.as_mapping().expect("Root should be a mapping");
 


### PR DESCRIPTION
When a mapping has a value of a sequence, and the sequence is preceded by a comment or blank line the sequence would not be recognised as a value of the mapping, e.g.

```yaml
items:
# comment
- value
```

would be parsed as:

```yaml
items:
```

rather than:

```yaml
items:
  - value
```

As with my [previous PR](https://github.com/jelmer/yaml-edit/pull/28) I'm happy to make any changes, or please feel free to take this code under the Apache-2.0 licence and adapt it yourself if that's easier than doing a PR review.

Again, LLMs were not used in any part of diagnosing or authoring this change.