### PR TITLE
Fix parsing of plain scalar keys containing spaces

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -836,13 +836,7 @@ impl Parser {
             }
             Some(SyntaxKind::PIPE) => self.parse_literal_block_scalar(),
             Some(SyntaxKind::GREATER) => self.parse_folded_block_scalar(),
-            Some(
-                SyntaxKind::STRING
-                | SyntaxKind::INT
-                | SyntaxKind::FLOAT
-                | SyntaxKind::BOOL
-                | SyntaxKind::NULL,
-            ) => {
+            Some(kind) if is_plain_scalar_kind(kind) => {
                 // In flow context, always parse as scalar
                 // In block context, check if it's a mapping key
                 // But not if we're already in a value context (prevents implicit nested mappings)
@@ -1719,6 +1713,18 @@ impl Parser {
     }
 }
 
+/// Kinds emitted by the lexer for plain (unquoted) scalar content.
+fn is_plain_scalar_kind(kind: SyntaxKind) -> bool {
+    matches!(
+        kind,
+        SyntaxKind::STRING
+            | SyntaxKind::INT
+            | SyntaxKind::FLOAT
+            | SyntaxKind::BOOL
+            | SyntaxKind::NULL
+    )
+}
+
 /// Standalone helper to detect implicit mapping pattern in flow collections.
 /// Takes an iterator of SyntaxKind tokens (in reverse order, as stored in Parser).
 /// Returns true if there's a colon at depth 0 before any comma or closing bracket.
@@ -2441,19 +2447,16 @@ impl Parser {
             return false;
         }
 
-        // Look ahead to see if there's a colon after the current token
-        // A valid mapping key should have a colon immediately after (with only whitespace)
-        let upcoming = self.upcoming_tokens();
-        for kind in upcoming {
-            match kind {
-                SyntaxKind::COLON => {
-                    return true;
-                }
-                SyntaxKind::WHITESPACE => continue,
-                // Any other token means this is not a simple mapping key
-                _ => {
-                    return false;
-                }
+        // Look ahead to see if there's a colon after the current token.
+        // Plain scalars can contain spaces, so a key may span multiple scalar
+        // tokens separated by whitespace before the terminating colon
+        // (e.g. `abc cba: value`).
+        for kind in self.upcoming_tokens() {
+            if kind == SyntaxKind::COLON {
+                return true;
+            }
+            if kind != SyntaxKind::WHITESPACE && !is_plain_scalar_kind(kind) {
+                return false;
             }
         }
         false
@@ -2674,18 +2677,21 @@ impl Parser {
         } else if self.current() == Some(SyntaxKind::REFERENCE) {
             // Handle alias as key (*b:)
             self.parse_alias();
-        } else if matches!(
-            self.current(),
-            Some(
-                SyntaxKind::STRING
-                    | SyntaxKind::INT
-                    | SyntaxKind::FLOAT
-                    | SyntaxKind::BOOL
-                    | SyntaxKind::NULL
-            )
-        ) {
+        } else if self.current().is_some_and(is_plain_scalar_kind) {
             self.builder.start_node(SyntaxKind::SCALAR.into());
-            self.bump(); // consume the key token
+            self.bump();
+            // Plain scalars can contain spaces, so absorb any following
+            // whitespace + scalar tokens until we reach the terminating colon
+            // (e.g. `abc cba: value`).
+            while self.current() == Some(SyntaxKind::WHITESPACE)
+                && self
+                    .upcoming_tokens()
+                    .next()
+                    .is_some_and(is_plain_scalar_kind)
+            {
+                self.bump(); // WHITESPACE inside the plain scalar
+                self.bump(); // next scalar segment
+            }
             self.builder.finish_node(); // SCALAR
         }
         self.builder.finish_node(); // KEY

--- a/tests/error_type_tests.rs
+++ b/tests/error_type_tests.rs
@@ -361,3 +361,62 @@ fn test_nested_unclosed_bracket_exact_error() {
         "2:18: Unclosed flow sequence. Expected: ']' to close sequence. Found: end of input. Context: in flow sequence. Suggestion: Add ']' to close the array, or check for missing commas between elements"
     );
 }
+
+/// Test that plain scalar with spaces works as a key (issue #30).
+#[test]
+fn test_key_with_spaces_issue_30() {
+    let yaml = "xyz: 1\nabc cba: 2\nfoo: 3\n";
+    let parsed = YamlFile::parse(yaml);
+    let errors = parsed.errors();
+    assert_eq!(
+        errors.len(),
+        0,
+        "Should parse without errors, got: {:?}",
+        errors
+    );
+
+    let tree = parsed.tree();
+    let doc = tree.document().expect("Should have document");
+    let mapping = doc.as_mapping().expect("Should be a mapping");
+
+    let keys: Vec<String> = mapping
+        .iter()
+        .map(|(k, _)| k.as_scalar().map(|s| s.as_string()).unwrap_or_default())
+        .collect();
+
+    assert_eq!(
+        keys,
+        vec!["xyz".to_string(), "abc cba".to_string(), "foo".to_string()]
+    );
+
+    // Round-trip: parsed tree must serialize back to the original input.
+    use rowan::ast::AstNode;
+    assert_eq!(tree.syntax().text().to_string(), yaml);
+}
+
+/// Multi-word keys should work in nested (indented) mappings too.
+#[test]
+fn test_multi_word_key_nested() {
+    let yaml = "outer:\n  abc cba: 2\n  foo: 3\n";
+    let parsed = YamlFile::parse(yaml);
+    assert_eq!(parsed.errors(), Vec::<String>::new());
+    let doc = parsed.tree().document().unwrap();
+    let outer = doc.as_mapping().unwrap();
+    let inner = outer.get("outer").unwrap();
+    let inner_map = inner.as_mapping().expect("nested mapping");
+    let val = inner_map
+        .get("abc cba")
+        .and_then(|n| n.as_scalar().cloned())
+        .expect("multi-word nested key");
+    assert_eq!(val.as_string(), "2");
+}
+
+/// A multi-word scalar with no colon must NOT be treated as a mapping.
+#[test]
+fn test_multi_word_scalar_without_colon_is_scalar() {
+    let yaml = "abc cba\n";
+    let parsed = YamlFile::parse(yaml);
+    let doc = parsed.tree().document().unwrap();
+    let scalar = doc.as_scalar().expect("should be a scalar, not mapping");
+    assert_eq!(scalar.as_string(), "abc cba");
+}

--- a/tests/parsing_bugs.rs
+++ b/tests/parsing_bugs.rs
@@ -535,8 +535,9 @@ colon_end: "ends with:"
 }
 
 #[test]
-fn test_no_false_mapping_with_colon_later() {
-    // Test that tokens with colons appearing later don't become mapping keys
+fn test_multi_word_key_in_sequence_item() {
+    // Plain scalars may contain spaces, so a mapping key inside a sequence
+    // item can be multiple words (per YAML 1.2 spec, matching PyYAML behavior).
     let yaml = r#"
 - item1: value1
 - item2 has text: but not a key
@@ -549,28 +550,33 @@ fn test_no_false_mapping_with_colon_later() {
 
     assert_eq!(sequence.len(), 3, "Should have 3 items");
 
-    // First item should be a mapping
     let item0 = sequence.get(0).expect("Should have item 0");
-    assert!(
-        item0.as_mapping().is_some(),
-        "First item should be a mapping"
+    let mapping0 = item0.as_mapping().expect("First item should be a mapping");
+    assert_eq!(
+        mapping0
+            .get("item1")
+            .and_then(|n| n.as_scalar().cloned())
+            .expect("item1 should exist")
+            .as_string(),
+        "value1"
     );
 
-    // Second item should be a scalar (not treated as mapping due to colon position)
     let item1 = sequence.get(1).expect("Should have item 1");
-    if let Some(scalar) = item1.as_scalar() {
-        assert_eq!(scalar.as_string(), "item2 has text: but not a key");
-    } else {
-        panic!("Second item should be a scalar, not a mapping");
-    }
+    let mapping1 = item1
+        .as_mapping()
+        .expect("Second item should be a mapping with multi-word key");
+    assert_eq!(
+        mapping1
+            .get("item2 has text")
+            .and_then(|n| n.as_scalar().cloned())
+            .expect("'item2 has text' should be a key")
+            .as_string(),
+        "but not a key"
+    );
 
-    // Third item should be a scalar
     let item2 = sequence.get(2).expect("Should have item 2");
-    if let Some(scalar) = item2.as_scalar() {
-        assert_eq!(scalar.as_string(), "item3");
-    } else {
-        panic!("Third item should be a scalar");
-    }
+    let scalar = item2.as_scalar().expect("Third item should be a scalar");
+    assert_eq!(scalar.as_string(), "item3");
 }
 
 #[test]


### PR DESCRIPTION
`is_mapping_key` bailed on the second scalar token in a multi-word key like `abc cba:`, so the whole entry got emitted as an ERROR node. Extend the lookahead (and the key-consuming loop in `parse_mapping_key_value_pair`) to absorb scalar+whitespace segments up to the terminating colon, matching YAML 1.2 semantics.

Fixes #30.