### PR TITLE
Lex plain scalars with internal whitespace as a single token

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -251,6 +251,42 @@ impl From<SyntaxKind> for rowan::SyntaxKind {
     }
 }
 
+/// Decide whether the whitespace run starting at `ws_idx` is internal to a
+/// plain scalar or a real terminator. Internal whitespace is followed by
+/// more plain-scalar content on the same line; a terminator is followed by
+/// end-of-line, end-of-input, a `#` comment marker, a `:` that ends the
+/// scalar (colon + whitespace/EOF), a flow indicator, or any other YAML
+/// special character.
+///
+/// Whitespace before a flow indicator is treated as a terminator even in
+/// block context: while the main loop treats `[](){},` as scalar content
+/// when they appear directly (no leading space), a space introduces a
+/// clear boundary that should be preserved as its own WHITESPACE token.
+///
+/// Caller must guarantee the character at `ws_idx` is a space or tab.
+fn plain_scalar_continues_past_whitespace(input: &str, ws_idx: usize, _flow_depth: u32) -> bool {
+    let rest = &input[ws_idx..];
+    // Find the first non-whitespace char in the run.
+    let (offset, next) = match rest.char_indices().find(|(_, c)| *c != ' ' && *c != '\t') {
+        Some(v) => v,
+        None => return false,
+    };
+    match next {
+        '\n' | '\r' | '#' => false,
+        ',' | '[' | ']' | '{' | '}' => false,
+        ':' => {
+            let colon_pos = ws_idx + offset;
+            let after_colon = &input[colon_pos + 1..];
+            after_colon
+                .chars()
+                .next()
+                .is_some_and(|nc| !nc.is_whitespace())
+        }
+        c if is_yaml_special(c) => false,
+        _ => true,
+    }
+}
+
 /// Helper to read a scalar value starting from current position
 fn read_scalar_from<'a>(
     chars: &mut std::iter::Peekable<std::str::CharIndices<'a>>,
@@ -761,16 +797,37 @@ pub fn lex_with_validation_config<'a>(
                 let mut end_idx = start_idx + ch.len_utf8();
 
                 // Read the rest of the scalar normally, including embedded hyphens
-                while let Some((idx, next_ch)) = chars.peek() {
-                    if next_ch.is_whitespace() {
+                while let Some((idx, next_ch)) = chars.peek().copied() {
+                    // Line breaks always terminate the current scalar token.
+                    if next_ch == '\n' || next_ch == '\r' {
                         break;
+                    }
+
+                    // Intra-line whitespace (space/tab) is part of a plain
+                    // scalar when followed by more scalar content on the same
+                    // line. Per YAML 1.2, plain scalars may contain single or
+                    // multiple internal spaces, but stop at line break, at
+                    // ` #` (comment start), or at end of line.
+                    if next_ch == ' ' || next_ch == '\t' {
+                        if !plain_scalar_continues_past_whitespace(input, idx, flow_depth) {
+                            break;
+                        }
+                        // Absorb the whitespace run into the scalar
+                        while let Some((wi, wc)) = chars.peek().copied() {
+                            if wc != ' ' && wc != '\t' {
+                                break;
+                            }
+                            end_idx = wi + wc.len_utf8();
+                            chars.next();
+                        }
+                        continue;
                     }
 
                     // Check for YAML special characters
                     // Special handling for colon: only special if followed by whitespace or EOF
-                    if *next_ch == ':' {
+                    if next_ch == ':' {
                         // Peek ahead one more to check if colon is followed by whitespace
-                        let next_idx = *idx + next_ch.len_utf8();
+                        let next_idx = idx + next_ch.len_utf8();
                         if next_idx >= input.len() {
                             // Colon at EOF - stop here (treat as mapping indicator)
                             break;
@@ -781,15 +838,15 @@ pub fn lex_with_validation_config<'a>(
                             }
                         }
                         // Colon not followed by whitespace - continue as part of scalar
-                        end_idx = *idx + next_ch.len_utf8();
+                        end_idx = idx + next_ch.len_utf8();
                         chars.next();
                         continue;
                     }
 
                     // Check other special characters (excluding hyphen and colon)
-                    if is_yaml_special_except(*next_ch, "-:") {
+                    if is_yaml_special_except(next_ch, "-:") {
                         // In block context, flow indicators do NOT break scalars
-                        if flow_depth == 0 && matches!(*next_ch, '[' | ']' | '{' | '}' | ',') {
+                        if flow_depth == 0 && matches!(next_ch, '[' | ']' | '{' | '}' | ',') {
                             // do nothing, let it be part of the scalar
                         } else {
                             break;
@@ -797,20 +854,20 @@ pub fn lex_with_validation_config<'a>(
                     }
 
                     // Special case: check if hyphen is a sequence marker
-                    if *next_ch == '-' {
+                    if next_ch == '-' {
                         // A hyphen is only a sequence marker if it's at line start
                         // and this scalar is already complete (we're at a word boundary)
-                        let line_start = input[..(*idx)].rfind('\n').map(|p| p + 1).unwrap_or(0);
-                        let before_hyphen = &input[line_start..*idx];
+                        let line_start = input[..idx].rfind('\n').map(|p| p + 1).unwrap_or(0);
+                        let before_hyphen = &input[line_start..idx];
 
                         // If there's only whitespace before the hyphen, it might be a sequence marker
                         // Break here to let the main loop handle it
-                        if before_hyphen.chars().all(|c| c == ' ' || c == '\t') && *idx == end_idx {
+                        if before_hyphen.chars().all(|c| c == ' ' || c == '\t') && idx == end_idx {
                             break;
                         }
                     }
 
-                    end_idx = *idx + next_ch.len_utf8();
+                    end_idx = idx + next_ch.len_utf8();
                     chars.next();
                 }
 
@@ -1234,13 +1291,17 @@ double: "quoted""#;
         let input = "line with - and + and : characters";
         let tokens = lex(input);
 
-        // With context-aware hyphen parsing, the standalone hyphen with spaces
-        // is treated as a string because it's not a sequence marker
+        // Plain scalars absorb intra-line whitespace until they hit a real
+        // terminator, so `line with` is one STRING and the standalone `-`
+        // between spaces is another (not a sequence marker mid-line).
+        assert!(tokens
+            .iter()
+            .any(|(kind, text)| *kind == SyntaxKind::STRING && *text == "line with"));
         assert!(tokens
             .iter()
             .any(|(kind, text)| *kind == SyntaxKind::STRING && *text == "-"));
 
-        // Plus and colon are still tokenized as special characters
+        // Plus and colon remain separately tokenized.
         assert!(tokens
             .iter()
             .any(|(kind, text)| *kind == SyntaxKind::PLUS && *text == "+"));
@@ -1248,19 +1309,9 @@ double: "quoted""#;
             .iter()
             .any(|(kind, text)| *kind == SyntaxKind::COLON && *text == ":"));
 
-        // Should also have the word tokens
-        assert!(tokens
-            .iter()
-            .any(|(kind, text)| *kind == SyntaxKind::STRING && *text == "line"));
-        assert!(tokens
-            .iter()
-            .any(|(kind, text)| *kind == SyntaxKind::STRING && *text == "with"));
-        assert!(tokens
-            .iter()
-            .any(|(kind, text)| *kind == SyntaxKind::STRING && *text == "and"));
-        assert!(tokens
-            .iter()
-            .any(|(kind, text)| *kind == SyntaxKind::STRING && *text == "characters"));
+        // Round-trip: concatenating tokens reproduces input.
+        let joined: String = tokens.iter().map(|(_, t)| *t).collect();
+        assert_eq!(joined, input);
     }
 
     #[test]
@@ -1691,12 +1742,15 @@ double: "quoted""#;
 
     #[test]
     fn test_dash_in_multiline_values() {
-        // Test multiline with dashes
+        // Test multiline with dashes: plain scalars absorb intra-line
+        // whitespace, so the first line becomes one STRING token ending
+        // in the trailing hyphen (hyphen-at-end-of-word is scalar content,
+        // not a sequence marker mid-scalar).
         let input = "description: This is a multi-\n  line value with dashes";
         let tokens = lex(input);
         assert!(tokens
             .iter()
-            .any(|(kind, text)| *kind == SyntaxKind::STRING && *text == "multi-"));
+            .any(|(kind, text)| *kind == SyntaxKind::STRING && *text == "This is a multi-"));
 
         // Test continuation with sequence-like line
         let input = "text: value\n  - but this is not a sequence";

--- a/tests/corner_cases.rs
+++ b/tests/corner_cases.rs
@@ -1,0 +1,304 @@
+//! Corner cases for plain scalar with internal whitespace (issue #30).
+//! This test file is run against both the parser-fix and lexer-fix branches.
+
+use std::str::FromStr;
+
+use rowan::ast::AstNode;
+use yaml_edit::{Mapping, YamlFile};
+
+fn keys_of(mapping: &Mapping) -> Vec<String> {
+    mapping
+        .iter()
+        .map(|(k, _)| k.as_scalar().map(|s| s.as_string()).unwrap_or_default())
+        .collect()
+}
+
+fn get_scalar(mapping: &Mapping, key: &str) -> Option<String> {
+    mapping
+        .get(key)
+        .and_then(|n| n.as_scalar().cloned())
+        .map(|s| s.as_string())
+}
+
+fn parse_ok(yaml: &str) -> YamlFile {
+    let parsed = YamlFile::parse(yaml);
+    let errors = parsed.errors();
+    assert!(
+        errors.is_empty(),
+        "expected no errors for {:?}, got: {:?}",
+        yaml,
+        errors
+    );
+    parsed.tree()
+}
+
+fn assert_roundtrip(yaml: &str) {
+    let tree = parse_ok(yaml);
+    assert_eq!(
+        tree.syntax().text().to_string(),
+        yaml,
+        "roundtrip mismatch for {:?}",
+        yaml
+    );
+}
+
+fn top_mapping(yaml: &str) -> Mapping {
+    parse_ok(yaml).document().unwrap().as_mapping().unwrap()
+}
+
+// ---------- A. Basic multi-word keys ----------
+
+#[test]
+fn a1_basic_two_word_key() {
+    let yaml = "abc cba: value\n";
+    assert_roundtrip(yaml);
+    let mapping = top_mapping(yaml);
+    assert_eq!(keys_of(&mapping), vec!["abc cba"]);
+    assert_eq!(get_scalar(&mapping, "abc cba"), Some("value".into()));
+}
+
+#[test]
+fn a2_many_word_key() {
+    let yaml = "a b c d: value\n";
+    assert_roundtrip(yaml);
+    assert_eq!(keys_of(&top_mapping(yaml)), vec!["a b c d"]);
+}
+
+#[test]
+fn a3_multiple_spaces_in_key() {
+    let yaml = "abc   cba: value\n";
+    assert_roundtrip(yaml);
+    assert_eq!(keys_of(&top_mapping(yaml)), vec!["abc   cba"]);
+}
+
+#[test]
+fn a4_tab_in_key() {
+    let yaml = "abc\tcba: value\n";
+    assert_roundtrip(yaml);
+    assert_eq!(keys_of(&top_mapping(yaml)), vec!["abc\tcba"]);
+}
+
+#[test]
+fn a5_space_before_colon() {
+    let yaml = "abc cba : value\n";
+    assert_roundtrip(yaml);
+    // The key itself doesn't include trailing whitespace.
+    assert_eq!(keys_of(&top_mapping(yaml)), vec!["abc cba"]);
+}
+
+#[test]
+fn a6_multi_word_scalar_no_colon() {
+    let yaml = "abc cba\n";
+    let tree = parse_ok(yaml);
+    let scalar = tree
+        .document()
+        .unwrap()
+        .as_scalar()
+        .expect("should be scalar, not mapping");
+    assert_eq!(scalar.as_string(), "abc cba");
+}
+
+// ---------- B. Multi-word values ----------
+
+#[test]
+fn b1_value_with_spaces() {
+    let yaml = "key: abc cba\n";
+    assert_roundtrip(yaml);
+    assert_eq!(
+        get_scalar(&top_mapping(yaml), "key"),
+        Some("abc cba".into())
+    );
+}
+
+#[test]
+fn b2_value_with_spaces_then_key() {
+    let yaml = "key: abc cba\nkey2: value\n";
+    assert_roundtrip(yaml);
+    let mapping = top_mapping(yaml);
+    assert_eq!(get_scalar(&mapping, "key"), Some("abc cba".into()));
+    assert_eq!(get_scalar(&mapping, "key2"), Some("value".into()));
+}
+
+// ---------- C. Comments ----------
+
+#[test]
+fn c1_comment_after_value() {
+    let yaml = "key: value # comment\n";
+    assert_roundtrip(yaml);
+    assert_eq!(get_scalar(&top_mapping(yaml), "key"), Some("value".into()));
+}
+
+#[test]
+fn c2_comment_after_multi_word_key_value() {
+    let yaml = "abc cba: value # comment\n";
+    assert_roundtrip(yaml);
+    assert_eq!(
+        get_scalar(&top_mapping(yaml), "abc cba"),
+        Some("value".into())
+    );
+}
+
+#[test]
+fn c3_comment_after_multi_word_value() {
+    let yaml = "key: abc cba # comment\n";
+    assert_roundtrip(yaml);
+    assert_eq!(
+        get_scalar(&top_mapping(yaml), "key"),
+        Some("abc cba".into())
+    );
+}
+
+// NOTE: `#` mid-word (e.g. `key: abc#def`) is currently mishandled by the
+// lexer, which unconditionally treats `#` as a comment start. This is a
+// pre-existing limitation independent of the multi-word scalar fix.
+
+// ---------- D. Colons in keys ----------
+
+#[test]
+fn d1_url_key_with_colon() {
+    let yaml = "http://example.com: value\n";
+    assert_roundtrip(yaml);
+    assert_eq!(
+        get_scalar(&top_mapping(yaml), "http://example.com"),
+        Some("value".into())
+    );
+}
+
+// ---------- E. Sequences ----------
+
+#[test]
+fn e1_sequence_item_multi_word() {
+    let yaml = "- abc cba\n- foo\n";
+    assert_roundtrip(yaml);
+    let tree = parse_ok(yaml);
+    let seq = tree.document().unwrap().as_sequence().unwrap();
+    assert_eq!(seq.len(), 2);
+    let s0 = seq.get(0).unwrap();
+    assert_eq!(s0.as_scalar().unwrap().as_string(), "abc cba");
+    let s1 = seq.get(1).unwrap();
+    assert_eq!(s1.as_scalar().unwrap().as_string(), "foo");
+}
+
+#[test]
+fn e2_sequence_of_multi_word_mapping() {
+    let yaml = "- abc cba: value\n- foo: bar\n";
+    assert_roundtrip(yaml);
+    let tree = parse_ok(yaml);
+    let seq = tree.document().unwrap().as_sequence().unwrap();
+    assert_eq!(seq.len(), 2);
+    let n0 = seq.get(0).unwrap();
+    let m0 = n0.as_mapping().unwrap();
+    assert_eq!(get_scalar(m0, "abc cba"), Some("value".into()));
+    let n1 = seq.get(1).unwrap();
+    let m1 = n1.as_mapping().unwrap();
+    assert_eq!(get_scalar(m1, "foo"), Some("bar".into()));
+}
+
+#[test]
+fn e3_nested_multi_word_key() {
+    let yaml = "outer:\n  abc cba: 2\n  foo: 3\n";
+    assert_roundtrip(yaml);
+    let outer = top_mapping(yaml);
+    let inner_node = outer.get("outer").unwrap();
+    let inner = inner_node.as_mapping().unwrap();
+    assert_eq!(get_scalar(inner, "abc cba"), Some("2".into()));
+    assert_eq!(get_scalar(inner, "foo"), Some("3".into()));
+}
+
+// ---------- F. Flow context ----------
+
+#[test]
+fn f1_flow_mapping_multi_word_key() {
+    let yaml = "{abc cba: value}";
+    assert_eq!(
+        get_scalar(&top_mapping(yaml), "abc cba"),
+        Some("value".into())
+    );
+}
+
+#[test]
+fn f2_flow_sequence_multi_word_items() {
+    let yaml = "[abc cba, def ghi]";
+    let tree = parse_ok(yaml);
+    let seq = tree.document().unwrap().as_sequence().unwrap();
+    assert_eq!(seq.len(), 2);
+    let s0 = seq.get(0).unwrap();
+    assert_eq!(s0.as_scalar().unwrap().as_string(), "abc cba");
+    let s1 = seq.get(1).unwrap();
+    assert_eq!(s1.as_scalar().unwrap().as_string(), "def ghi");
+}
+
+#[test]
+fn f3_flow_mapping_multi_word_value() {
+    let yaml = "{a: b c d}";
+    assert_eq!(get_scalar(&top_mapping(yaml), "a"), Some("b c d".into()));
+}
+
+// ---------- G. Special characters mid-scalar ----------
+
+#[test]
+fn g1_hyphen_at_word_end_in_key() {
+    // "abc-" is a single word, `cba` follows after space; per YAML they merge.
+    let yaml = "abc- cba: value\n";
+    assert_eq!(
+        get_scalar(&top_mapping(yaml), "abc- cba"),
+        Some("value".into())
+    );
+}
+
+#[test]
+fn g2_numbers_as_words_in_key() {
+    let yaml = "abc 123: value\n";
+    assert_roundtrip(yaml);
+    assert_eq!(
+        get_scalar(&top_mapping(yaml), "abc 123"),
+        Some("value".into())
+    );
+}
+
+#[test]
+fn g3_bool_words_as_key() {
+    let yaml = "true false: value\n";
+    assert_roundtrip(yaml);
+    assert_eq!(
+        get_scalar(&top_mapping(yaml), "true false"),
+        Some("value".into())
+    );
+}
+
+// ---------- H. Multi-line ----------
+
+#[test]
+fn h1_multi_line_plain_scalar_value() {
+    // Plain scalar continuation across lines (folded to space).
+    let yaml = "key: abc cba\n  more text\n";
+    let mapping = top_mapping(yaml);
+    // Per YAML, multi-line plain scalars fold newlines to spaces.
+    assert_eq!(
+        get_scalar(&mapping, "key"),
+        Some("abc cba more text".into())
+    );
+}
+
+// ---------- I. Round-trip stability ----------
+
+#[test]
+fn i1_roundtrip_issue_30_original() {
+    assert_roundtrip("xyz: 1\nabc cba: 2\nfoo: 3\n");
+}
+
+#[test]
+fn i2_roundtrip_with_indent_and_comments() {
+    let yaml = "# top comment\nouter:\n  # inner comment\n  abc cba: 1\n  foo: 2\n";
+    assert_roundtrip(yaml);
+}
+
+// ---------- J. Setter round-trip ----------
+
+#[test]
+fn j1_read_then_serialize() {
+    let yaml = "abc cba: original\n";
+    let f = YamlFile::from_str(yaml).unwrap();
+    let output = f.to_string();
+    assert_eq!(output, yaml);
+}

--- a/tests/error_type_tests.rs
+++ b/tests/error_type_tests.rs
@@ -361,3 +361,62 @@ fn test_nested_unclosed_bracket_exact_error() {
         "2:18: Unclosed flow sequence. Expected: ']' to close sequence. Found: end of input. Context: in flow sequence. Suggestion: Add ']' to close the array, or check for missing commas between elements"
     );
 }
+
+/// Test that plain scalar with spaces works as a key (issue #30).
+#[test]
+fn test_key_with_spaces_issue_30() {
+    let yaml = "xyz: 1\nabc cba: 2\nfoo: 3\n";
+    let parsed = YamlFile::parse(yaml);
+    let errors = parsed.errors();
+    assert_eq!(
+        errors.len(),
+        0,
+        "Should parse without errors, got: {:?}",
+        errors
+    );
+
+    let tree = parsed.tree();
+    let doc = tree.document().expect("Should have document");
+    let mapping = doc.as_mapping().expect("Should be a mapping");
+
+    let keys: Vec<String> = mapping
+        .iter()
+        .map(|(k, _)| k.as_scalar().map(|s| s.as_string()).unwrap_or_default())
+        .collect();
+
+    assert_eq!(
+        keys,
+        vec!["xyz".to_string(), "abc cba".to_string(), "foo".to_string()]
+    );
+
+    // Round-trip: parsed tree must serialize back to the original input.
+    use rowan::ast::AstNode;
+    assert_eq!(tree.syntax().text().to_string(), yaml);
+}
+
+/// Multi-word keys should work in nested (indented) mappings too.
+#[test]
+fn test_multi_word_key_nested() {
+    let yaml = "outer:\n  abc cba: 2\n  foo: 3\n";
+    let parsed = YamlFile::parse(yaml);
+    assert_eq!(parsed.errors(), Vec::<String>::new());
+    let doc = parsed.tree().document().unwrap();
+    let outer = doc.as_mapping().unwrap();
+    let inner = outer.get("outer").unwrap();
+    let inner_map = inner.as_mapping().expect("nested mapping");
+    let val = inner_map
+        .get("abc cba")
+        .and_then(|n| n.as_scalar().cloned())
+        .expect("multi-word nested key");
+    assert_eq!(val.as_string(), "2");
+}
+
+/// A multi-word scalar with no colon must NOT be treated as a mapping.
+#[test]
+fn test_multi_word_scalar_without_colon_is_scalar() {
+    let yaml = "abc cba\n";
+    let parsed = YamlFile::parse(yaml);
+    let doc = parsed.tree().document().unwrap();
+    let scalar = doc.as_scalar().expect("should be a scalar, not mapping");
+    assert_eq!(scalar.as_string(), "abc cba");
+}

--- a/tests/parsing_bugs.rs
+++ b/tests/parsing_bugs.rs
@@ -535,8 +535,9 @@ colon_end: "ends with:"
 }
 
 #[test]
-fn test_no_false_mapping_with_colon_later() {
-    // Test that tokens with colons appearing later don't become mapping keys
+fn test_multi_word_key_in_sequence_item() {
+    // Plain scalars may contain spaces, so a mapping key inside a sequence
+    // item can be multiple words (per YAML 1.2 spec, matching PyYAML behavior).
     let yaml = r#"
 - item1: value1
 - item2 has text: but not a key
@@ -549,28 +550,33 @@ fn test_no_false_mapping_with_colon_later() {
 
     assert_eq!(sequence.len(), 3, "Should have 3 items");
 
-    // First item should be a mapping
     let item0 = sequence.get(0).expect("Should have item 0");
-    assert!(
-        item0.as_mapping().is_some(),
-        "First item should be a mapping"
+    let mapping0 = item0.as_mapping().expect("First item should be a mapping");
+    assert_eq!(
+        mapping0
+            .get("item1")
+            .and_then(|n| n.as_scalar().cloned())
+            .expect("item1 should exist")
+            .as_string(),
+        "value1"
     );
 
-    // Second item should be a scalar (not treated as mapping due to colon position)
     let item1 = sequence.get(1).expect("Should have item 1");
-    if let Some(scalar) = item1.as_scalar() {
-        assert_eq!(scalar.as_string(), "item2 has text: but not a key");
-    } else {
-        panic!("Second item should be a scalar, not a mapping");
-    }
+    let mapping1 = item1
+        .as_mapping()
+        .expect("Second item should be a mapping with multi-word key");
+    assert_eq!(
+        mapping1
+            .get("item2 has text")
+            .and_then(|n| n.as_scalar().cloned())
+            .expect("'item2 has text' should be a key")
+            .as_string(),
+        "but not a key"
+    );
 
-    // Third item should be a scalar
     let item2 = sequence.get(2).expect("Should have item 2");
-    if let Some(scalar) = item2.as_scalar() {
-        assert_eq!(scalar.as_string(), "item3");
-    } else {
-        panic!("Third item should be a scalar");
-    }
+    let scalar = item2.as_scalar().expect("Third item should be a scalar");
+    assert_eq!(scalar.as_string(), "item3");
 }
 
 #[test]


### PR DESCRIPTION
Extend the fallthrough scalar reader to absorb intra-line spaces/tabs  when followed by more plain-scalar content on the same line. This lets `abc cba` lex as a single STRING instead of two tokens with a WHITESPACE between them, which is a truer reflection of the YAML 1.2 plain scalar production and fixes issue #30 without any parser-side workaround.

The helper `plain_scalar_continues_past_whitespace` scans forward past     the whitespace run and stops at line breaks, `#` (comment start), the     `: `/`:EOF` mapping indicator, flow indicators, and other YAML special     characters, so structural tokens still get emitted separately.

Two internal lexer tests that asserted word-by-word tokenization are     updated to reflect the coarser (and more spec-accurate) output. The     sequence-item test that assumed `- item2 has text: but not a key`     parses as a scalar is corrected to a mapping, matching PyYAML. 

Fixes #30