### PR TITLE
Fix nested value indent check for empty mapping values

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -1555,7 +1555,7 @@ impl Parser {
                 // Finish the MAPPING_ENTRY node
                 self.builder.finish_node();
             } else {
-                self.parse_mapping_key_value_pair();
+                self.parse_mapping_key_value_pair(base_indent);
             }
 
             // Progress guard: if no token was consumed this iteration we
@@ -2153,7 +2153,7 @@ impl Parser {
                 self.parse_explicit_key_entries();
                 break;
             }
-            self.parse_mapping_key_value_pair();
+            self.parse_mapping_key_value_pair(0);
             self.skip_ws_and_newlines();
             // Progress guard against any future case where the body consumes
             // nothing (e.g. recovery via synthetic-token insertion).
@@ -2657,7 +2657,7 @@ impl Parser {
         ]);
     }
 
-    fn parse_mapping_key_value_pair(&mut self) {
+    fn parse_mapping_key_value_pair(&mut self, base_indent: usize) {
         // Start MAPPING_ENTRY node to wrap the entire key-value pair
         self.builder.start_node(SyntaxKind::MAPPING_ENTRY.into());
 
@@ -2743,15 +2743,22 @@ impl Parser {
                 // If no indented content follows the comment, has_value stays false → implicit null
             } else if self.current() == Some(SyntaxKind::NEWLINE) {
                 self.skip_ws_and_newlines();
-                if self.current_line_indent != 0 {
+                if self.current_line_indent > base_indent {
+                    // Nested value is more indented than the enclosing mapping's
+                    // base indent — belongs to this key.
                     self.parse_value_with_base_indent(self.current_line_indent);
                     has_value = true;
-                } else if self.current() == Some(SyntaxKind::DASH) {
+                } else if self.current_line_indent == base_indent
+                    && self.current() == Some(SyntaxKind::DASH)
+                {
                     // Zero-indented sequence (same indentation as key)
                     // This is valid YAML: the sequence is the value for the key
-                    self.parse_sequence();
+                    self.parse_sequence_with_base_indent(base_indent);
                     has_value = true;
                 }
+                // Otherwise the "value" would be at the parent's indent or
+                // less, so this key has an implicit null value and what
+                // follows is a sibling entry.
             }
 
             // If no value present, create an implicit null scalar

--- a/tests/mapping_with_blank_lines_test.rs
+++ b/tests/mapping_with_blank_lines_test.rs
@@ -229,3 +229,58 @@ another: value
     let output = doc.to_string();
     assert_eq!(output, yaml);
 }
+
+#[test]
+fn test_issue_26_blank_line_between_key_and_nested_value() {
+    // Regression test for https://github.com/jelmer/yaml-edit/issues/26
+    let yaml = "foo: bar\n\nbaz:\n\n  qux: ~\n";
+
+    let doc = YamlFile::parse(yaml).to_result().unwrap();
+    let document = doc.document().unwrap();
+    let mapping = document.as_mapping().unwrap();
+
+    // Should have exactly two root-level keys: foo and baz
+    assert_eq!(mapping.len(), 2);
+    assert_eq!(
+        mapping.get("foo").unwrap().as_scalar().unwrap().as_string(),
+        "bar"
+    );
+
+    // baz should be a mapping containing qux
+    let baz = mapping.get_mapping("baz").unwrap();
+    assert_eq!(baz.len(), 1);
+    assert_eq!(
+        baz.get("qux").unwrap().as_scalar().unwrap().as_string(),
+        "~"
+    );
+
+    // Verify lossless round-trip
+    assert_eq!(doc.to_string(), yaml);
+}
+
+#[test]
+fn test_issue_26_comment_null_key_no_blank_line() {
+    // Related comment on issue #26: bar2 with no value, followed by bar3 at same indent
+    let yaml = "foo:\n  bar1: 42\n  bar2:\n  bar3: \"hello\"\n";
+
+    let doc = YamlFile::parse(yaml).to_result().unwrap();
+    let document = doc.document().unwrap();
+    let mapping = document.as_mapping().unwrap();
+
+    let foo = mapping.get_mapping("foo").unwrap();
+    // Should have three sibling keys: bar1, bar2, bar3
+    assert_eq!(foo.len(), 3);
+    assert_eq!(
+        foo.get("bar1").unwrap().as_scalar().unwrap().as_string(),
+        "42"
+    );
+    // bar2 has null value
+    assert!(foo.get("bar2").unwrap().as_scalar().is_some());
+    assert_eq!(
+        foo.get("bar3").unwrap().as_scalar().unwrap().as_string(),
+        "hello"
+    );
+
+    // Verify lossless round-trip
+    assert_eq!(doc.to_string(), yaml);
+}


### PR DESCRIPTION
A mapping key with no inline value would incorrectly slurp the following sibling entry as its nested value when that sibling was at the parent mapping's indent. Require the value's indent to be strictly greater than the enclosing mapping's base indent.