### PR TITLE
Add Alias::new and YamlBuilder::alias

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -27,6 +27,22 @@ impl YamlBuilder {
         }
     }
 
+    /// Start building from an alias (`*name`).
+    ///
+    /// `name` is the anchor name without the `*` prefix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use yaml_edit::YamlBuilder;
+    ///
+    /// let yaml = YamlBuilder::alias("shared").build();
+    /// assert_eq!(yaml.to_string(), "*shared");
+    /// ```
+    pub fn alias(name: impl AsRef<str>) -> Self {
+        Self::scalar(crate::yaml::Alias::new(name))
+    }
+
     /// Start building from a sequence.
     pub fn sequence() -> SequenceBuilder {
         SequenceBuilder::new()
@@ -586,6 +602,21 @@ mod tests {
     fn test_scalar_builder() {
         let yaml = YamlBuilder::scalar("hello world").build();
         assert_eq!(yaml.to_string(), "hello world");
+    }
+
+    #[test]
+    fn test_alias_builder() {
+        let yaml = YamlBuilder::alias("shared").build();
+        assert_eq!(yaml.to_string(), "*shared");
+    }
+
+    #[test]
+    fn test_mapping_builder_alias_value() {
+        let yaml = YamlBuilder::mapping()
+            .pair("ref", crate::yaml::Alias::new("shared"))
+            .build()
+            .build();
+        assert_eq!(yaml.to_string(), "ref: *shared");
     }
 
     #[test]

--- a/src/nodes/alias_node.rs
+++ b/src/nodes/alias_node.rs
@@ -2,10 +2,37 @@ use super::{Lang, SyntaxNode};
 use crate::as_yaml::{AsYaml, YamlKind};
 use crate::lex::SyntaxKind;
 use rowan::ast::AstNode;
+use rowan::GreenNodeBuilder;
 
 ast_node!(Alias, ALIAS, "A YAML alias reference (e.g., *anchor_name)");
 
 impl Alias {
+    /// Construct an alias that serializes as `*name`.
+    ///
+    /// `name` is the anchor name without the `*` prefix. The node implements
+    /// [`AsYaml`], so it can be passed to [`Mapping::set`](crate::Mapping::set)
+    /// and other mutation APIs without parsing a snippet.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    /// use yaml_edit::{Alias, Document};
+    ///
+    /// let doc = Document::from_str("shared: &shared value\nservice_a: old\n").unwrap();
+    /// let mapping = doc.as_mapping().unwrap();
+    /// mapping.set("service_a", Alias::new("shared"));
+    /// assert_eq!(doc.to_string(), "shared: &shared value\nservice_a: *shared\n");
+    /// ```
+    pub fn new(name: impl AsRef<str>) -> Self {
+        let text = format!("*{}", name.as_ref());
+        let mut builder = GreenNodeBuilder::new();
+        builder.start_node(SyntaxKind::ALIAS.into());
+        builder.token(SyntaxKind::REFERENCE.into(), &text);
+        builder.finish_node();
+        Alias(SyntaxNode::new_root_mut(builder.finish()))
+    }
+
     /// Get the full text of this alias including the `*` prefix
     pub fn value(&self) -> String {
         self.0.text().to_string()
@@ -59,8 +86,9 @@ impl AsYaml for Alias {
         _indent: usize,
         _flow_context: bool,
     ) -> bool {
+        builder.start_node(SyntaxKind::ALIAS.into());
         crate::as_yaml::copy_node_content(builder, &self.0);
-        // Aliases don't end with newlines
+        builder.finish_node();
         false
     }
 
@@ -281,5 +309,47 @@ items:
 
         // Should preserve the exact whitespace
         assert_eq!(output, yaml);
+    }
+
+    #[test]
+    fn test_alias_new_name_and_value() {
+        let alias = crate::Alias::new("shared");
+        assert_eq!(alias.name(), "shared");
+        assert_eq!(alias.value(), "*shared");
+        assert_eq!(alias.to_string(), "*shared");
+    }
+
+    #[test]
+    fn test_alias_new_set_replaces_value_and_keeps_anchor() {
+        use crate::Alias;
+
+        let doc = Document::from_str("shared: &shared value\nservice_a: old\n").unwrap();
+        let mapping = doc.as_mapping().unwrap();
+        mapping.set("service_a", Alias::new("shared"));
+        assert_eq!(
+            doc.to_string(),
+            "shared: &shared value\nservice_a: *shared\n"
+        );
+
+        let service_a = mapping.get("service_a").unwrap();
+        match service_a {
+            YamlNode::Alias(alias) => {
+                assert_eq!(alias.name(), "shared");
+                assert_eq!(alias.value(), "*shared");
+            }
+            other => panic!("Expected alias, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_alias_new_set_into_sequence() {
+        use crate::Alias;
+
+        let doc = Document::from_str("colors:\n  - &red '#FF0000'\n  - old\n").unwrap();
+        let mapping = doc.as_mapping().unwrap();
+        let colors_node = mapping.get("colors").unwrap();
+        let colors = colors_node.as_sequence().unwrap();
+        colors.set(1, Alias::new("red"));
+        assert_eq!(doc.to_string(), "colors:\n  - &red '#FF0000'\n  - *red\n");
     }
 }


### PR DESCRIPTION
Adds write-side construction for YAML aliases (`*name`) so callers do not have to parse a snippet.

## Problem

`Alias` was parse-only: `name()` / `value()` work on nodes the parser produced, but there was no constructor. `YamlBuilder` could start from a scalar, sequence, or mapping, but not an alias.

## Change

- `Alias::new("shared")` builds an `ALIAS` node with a `REFERENCE` token (`*shared`)
- `YamlBuilder::alias("shared")` matches `YamlBuilder::scalar`
- `Alias` already implemented `AsYaml`; `build_content` now emits an `ALIAS` wrapper (same pattern as `Mapping` / `Sequence`) so `Mapping::get` returns `YamlNode::Alias` after `set`

```rust
mapping.set("service_a", Alias::new("shared"));
// service_a: *shared
```

## Validation

- Unit tests with exact `assert_eq!` on `to_string()`, `name()`, and `value()`
- `Mapping::set` and `Sequence::set` keep sibling `&anchor` text
- `cargo test --lib --all-features`: 617 passed
- `cargo test --doc --all-features`: 70 passed
- `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean
- YAML Test Suite: ok

Ref #39
