### PR TITLE
Document that Mapping::set does not infer merge keys

### DIFF
--- a/src/anchor_resolution.rs
+++ b/src/anchor_resolution.rs
@@ -152,6 +152,11 @@ pub trait DocumentResolvedExt {
     /// This method resolves aliases (*alias) to their anchored values (&anchor),
     /// and supports merge keys (<<) for combining mappings.
     ///
+    /// Resolution is read-only. To write a merge or alias back, pass a mapping
+    /// that already contains `<<: *name` (or an alias node) to
+    /// [`Mapping::set`](crate::Mapping::set). `set` does not infer a merge
+    /// from a resolved object.
+    ///
     /// # Examples
     ///
     /// ```
@@ -377,6 +382,9 @@ fn merge_from_alias(
 ///
 /// Returned values are [`YamlNode`](crate::as_yaml::YamlNode)s backed by real
 /// CST nodes, so they preserve the original formatting and quoting style.
+///
+/// This view is read-only. [`Mapping::set`](crate::Mapping::set) replaces the
+/// value node you pass; it does not turn a resolved map back into `<<: *name`.
 ///
 /// # Examples
 ///

--- a/src/nodes/mapping.rs
+++ b/src/nodes/mapping.rs
@@ -1315,6 +1315,29 @@ impl Mapping {
     /// which return `bool` to indicate whether the anchor key was found.
     ///
     /// Mutates in place despite `&self` (see crate docs on interior mutability).
+    ///
+    /// `set` replaces the value with the node you pass. It does not infer
+    /// YAML 1.1 merge keys from a resolved map. To keep identity, pass an
+    /// alias node (`*name`) or a mapping that already contains `<<: *name`.
+    /// Merge **reads** (`get_resolved()`, `merged()`) stay separate from
+    /// this CST replace.
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    /// use yaml_edit::Document;
+    ///
+    /// let doc = Document::from_str(
+    ///     "shared: &shared\n  timeout: 30\n  retries: 3\nservice_a: old\n",
+    /// )
+    /// .unwrap();
+    /// let mapping = doc.as_mapping().unwrap();
+    /// let merge = Document::from_str("<<: *shared\ntimeout: 60\n").unwrap();
+    /// mapping.set("service_a", merge.as_mapping().unwrap());
+    /// assert_eq!(
+    ///     doc.to_string(),
+    ///     "shared: &shared\n  timeout: 30\n  retries: 3\nservice_a:\n  <<: *shared\n  timeout: 60\n"
+    /// );
+    /// ```
     pub fn set(&self, key: impl crate::AsYaml, value: impl crate::AsYaml) {
         self.set_as_yaml(key, value);
     }


### PR DESCRIPTION
Documents how to write merge keys and aliases through `Mapping::set`.

## Problem

`get_resolved()` / `merged()` already expand `<<: *name` and `*alias` on the read path. `set` is a CST replace. It does not infer a merge from a resolved map. That is easy to miss if you only read the merge APIs.

## Change

- Note on `Mapping::set`: pass an alias node (`*name`) or a mapping that already contains `<<: *name`
- Matching notes on `DocumentResolvedExt::get_resolved` and `MergedMapping` that those APIs are read-only

```rust
let merge = Document::from_str("<<: *shared\ntimeout: 60\n").unwrap();
mapping.set("service_a", merge.as_mapping().unwrap());
```

This does not change `set` behavior. Merge writes already work when the replacement CST contains `<<: *name`.

## Validation

- New rustdoc example on `Mapping::set` (exact `assert_eq!` of the serialized document)
- `cargo test --doc --all-features`: 69 passed
- `cargo test --lib --all-features`: 612 passed
- `cargo clippy --all-targets --all-features -- -D warnings` clean

Ref #39
