### PR TITLE
Replace ALIAS items in Sequence::set

### DIFF
--- a/src/nodes/sequence.rs
+++ b/src/nodes/sequence.rs
@@ -406,6 +406,7 @@ impl Sequence {
                                         SyntaxKind::SCALAR
                                             | SyntaxKind::MAPPING
                                             | SyntaxKind::SEQUENCE
+                                            | SyntaxKind::ALIAS
                                             | SyntaxKind::TAGGED_NODE
                                     ) =>
                                 {
@@ -763,6 +764,25 @@ mod tests {
         assert_eq!(
             values[1].as_scalar().map(|s| s.as_string()),
             Some("bar".to_string())
+        );
+    }
+
+    #[test]
+    fn test_sequence_set_alias() {
+        let yaml = "colors:\n  - *red\n  - keep\n";
+        let parsed = YamlFile::from_str(yaml).unwrap();
+        let doc = parsed.document().unwrap();
+        let mapping = doc.as_mapping().unwrap();
+        let colors_node = mapping.get("colors").unwrap();
+        let seq = colors_node.as_sequence().unwrap();
+
+        assert!(seq.set(0, "blue"));
+        assert_eq!(parsed.to_string(), "colors:\n  - blue\n  - keep\n");
+
+        let first = seq.get(0).unwrap();
+        assert_eq!(
+            first.as_scalar().map(|s| s.as_string()),
+            Some("blue".to_string())
         );
     }
 


### PR DESCRIPTION
`Sequence::set` now replaces an item whose current value is an alias (`*name`).

## Problem

`Sequence::items` already lists `ALIAS` as a value kind. `set` only replaced `SCALAR`, `MAPPING`, `SEQUENCE`, and `TAGGED_NODE`. An existing `*foo` slot was copied through and the new value was never inserted, so `set` returned `true` while the document stayed the same.

This is the same class of miss as tagged nodes (`test_sequence_set_tagged_node`).

## Change

Add `ALIAS` to the `set` kind match. One new test: `set(0, "blue")` on `- *red` becomes `- blue`, with exact `assert_eq!` on the document.

## Validation

- Red: `test_sequence_set_alias` left `colors:\n  - *red\n  - keep\n`
- Green: same test, document is `colors:\n  - blue\n  - keep\n`
- `cargo test --lib --all-features`: 613 passed
- `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` clean

Ref #39
