### PR TITLE
Wrap the concrete node in YamlNode::build_content

### DIFF
--- a/src/as_yaml.rs
+++ b/src/as_yaml.rs
@@ -538,7 +538,9 @@ impl AsYaml for YamlNode {
         _flow_context: bool,
     ) -> bool {
         let node = self.syntax();
+        builder.start_node(node.kind().into());
         copy_node_content(builder, node);
+        builder.finish_node();
         node.last_token()
             .map(|t| t.kind() == crate::lex::SyntaxKind::NEWLINE)
             .unwrap_or(false)
@@ -1012,6 +1014,25 @@ mod tests {
     use super::*;
     use crate::yaml::{Document, YamlFile};
     use std::str::FromStr;
+
+    #[test]
+    fn test_set_yaml_node_alias_round_trips_as_alias() {
+        let doc = Document::from_str("shared: &shared value\na: *shared\nb: old\n").unwrap();
+        let mapping = doc.as_mapping().unwrap();
+        mapping.set("b", mapping.get("a").unwrap());
+        assert_eq!(
+            doc.to_string(),
+            "shared: &shared value\na: *shared\nb: *shared\n"
+        );
+
+        match mapping.get("b").unwrap() {
+            YamlNode::Alias(alias) => {
+                assert_eq!(alias.name(), "shared");
+                assert_eq!(alias.value(), "*shared");
+            }
+            other => panic!("Expected alias, got {:?}", other),
+        }
+    }
 
     #[test]
     fn test_yaml_eq_different_quoting_styles() {


### PR DESCRIPTION
`YamlNode::build_content` now emits the concrete node (`ALIAS`, `SCALAR`, and the other `YamlNode` kinds) instead of only its children.

## Problem

`Mapping::set(k, mapping.get(other))` goes through `YamlNode`'s `AsYaml` impl. That impl called `copy_node_content`, which copies children only. For an alias the children are a bare `REFERENCE` token, so the new `VALUE` had no child node and `Mapping::get` returned `None`.

`Mapping` and `Sequence` already wrap themselves in `build_content`. `Alias::new` on #50 does the same for that type. This is the `set(k, get(other))` path.

## Change

Start a node of `syntax().kind()`, copy children into it, then finish. One test: copy `a: *shared` onto `b` and assert `get("b")` is `YamlNode::Alias`.

## Validation

- Red: `mapping.get("b")` was `None` after the copy
- Green: `b: *shared` and `get("b")` is `Alias { name: "shared" }`
- `cargo test --lib --all-features`: 613 passed
- `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` clean

Ref #39
