### PR TITLE
fix: return Err from JsonHandler::deserialize

### DIFF
--- a/src/custom_tags.rs
+++ b/src/custom_tags.rs
@@ -715,9 +715,15 @@ mod tests {
     #[test]
     fn test_json_handler_deserialize_returns_err_not_panic() {
         let handler = JsonHandler;
-        assert!(handler.deserialize("[1,2]").is_err());
-        assert!(handler.deserialize("{\"a\":1}").is_err());
-        assert!(handler.deserialize("\"").is_err());
+        let array = handler.deserialize("[1,2]").unwrap_err();
+        assert_eq!(array.tag, "!json");
+        assert_eq!(array.message, "JSON arrays are not supported");
+        let object = handler.deserialize("{\"a\":1}").unwrap_err();
+        assert_eq!(object.tag, "!json");
+        assert_eq!(object.message, "JSON objects are not supported");
+        let quote = handler.deserialize("\"").unwrap_err();
+        assert_eq!(quote.tag, "!json");
+        assert_eq!(quote.message, "Unterminated quoted string");
         assert_eq!(
             handler
                 .deserialize("\"hello\"")

--- a/src/custom_tags.rs
+++ b/src/custom_tags.rs
@@ -500,13 +500,27 @@ impl CustomTagHandler for JsonHandler {
     fn deserialize(&self, content: &str) -> Result<YamlValue, CustomTagError> {
         // TODO: implement a proper JSON parser here
         let content = content.trim();
-        if content.starts_with('"') && content.ends_with('"') {
+        if content.len() >= 2 && content.starts_with('"') && content.ends_with('"') {
             let inner = &content[1..content.len() - 1];
             Ok(YamlValue::scalar(inner))
         } else if content.starts_with('[') && content.ends_with(']') {
-            unimplemented!("JsonHandler::deserialize does not yet parse JSON arrays")
+            Err(CustomTagError::with_content(
+                "!json",
+                "JSON arrays are not supported",
+                content,
+            ))
         } else if content.starts_with('{') && content.ends_with('}') {
-            unimplemented!("JsonHandler::deserialize does not yet parse JSON objects")
+            Err(CustomTagError::with_content(
+                "!json",
+                "JSON objects are not supported",
+                content,
+            ))
+        } else if content == "\"" || content == "'" {
+            Err(CustomTagError::with_content(
+                "!json",
+                "Unterminated quoted string",
+                content,
+            ))
         } else {
             Ok(YamlValue::scalar(content))
         }
@@ -696,6 +710,23 @@ mod tests {
 
         // Test validation (implicit through deserialization)
         assert!(handler.validate("\"valid\"").is_ok());
+    }
+
+    #[test]
+    fn test_json_handler_deserialize_returns_err_not_panic() {
+        let handler = JsonHandler;
+        assert!(handler.deserialize("[1,2]").is_err());
+        assert!(handler.deserialize("{\"a\":1}").is_err());
+        assert!(handler.deserialize("\"").is_err());
+        assert_eq!(
+            handler
+                .deserialize("\"hello\"")
+                .unwrap()
+                .as_scalar()
+                .unwrap()
+                .value(),
+            "hello"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`JsonHandler::deserialize` is a public `Result` API. Arrays, objects, and a lone `"` used to panic instead of returning `Err`.

## Problem

`CustomTagHandler::deserialize` is specified to return `Result`. The built-in `JsonHandler` called `unimplemented!` for `[...]` and `{...}`, and sliced `[1..0]` on input `"`. Default `validate` calls `deserialize`. `CustomTagRegistry` holds `handlers.read()` across the call, so a panic poisons the lock.

## Change

Return `CustomTagError` for those inputs. A quoted string is only unquoted when `len() >= 2`.

## Validation

```
Red:  cargo test --lib test_json_handler_deserialize_returns_err_not_panic
      unimplemented! panic at custom_tags.rs:507
Green: same test, ok
```

## Origin

Present since the initial rewrite ([`3c9b46e`](https://github.com/jelmer/yaml-edit/commit/3c9b46e), 2026-02-25).
