### PR TITLE
fix: do not panic on a one-character quoted scalar

### DIFF
--- a/src/nodes/scalar_node.rs
+++ b/src/nodes/scalar_node.rs
@@ -55,10 +55,10 @@ impl Scalar {
         let text = self.value();
 
         // Handle quoted strings
-        if text.starts_with('"') && text.ends_with('"') {
+        if text.len() >= 2 && text.starts_with('"') && text.ends_with('"') {
             // Double-quoted string - handle escape sequences
             ScalarValue::parse_escape_sequences(&text[1..text.len() - 1])
-        } else if text.starts_with('\'') && text.ends_with('\'') {
+        } else if text.len() >= 2 && text.starts_with('\'') && text.ends_with('\'') {
             // Single-quoted string - handle '' -> ' escape and fold multi-line strings
             let content = &text[1..text.len() - 1];
             let unescaped = content.replace("''", "'");
@@ -248,8 +248,9 @@ impl Scalar {
     /// Check if this scalar is quoted
     pub fn is_quoted(&self) -> bool {
         let text = self.value();
-        (text.starts_with('"') && text.ends_with('"'))
-            || (text.starts_with('\'') && text.ends_with('\''))
+        text.len() >= 2
+            && ((text.starts_with('"') && text.ends_with('"'))
+                || (text.starts_with('\'') && text.ends_with('\'')))
     }
 
     /// Get the raw content of this scalar with outer quotes stripped, but
@@ -473,6 +474,20 @@ impl TryFrom<&Scalar> for bool {
 mod tests {
     use crate::Document;
     use std::str::FromStr;
+
+    #[test]
+    fn test_unterminated_quote_as_string_does_not_panic() {
+        let (doc, errors) = Document::from_str_relaxed("\"");
+        assert!(!errors.is_empty());
+        let scalar = doc.as_scalar().expect("relaxed parse keeps a scalar");
+        assert_eq!(scalar.as_string(), "\"");
+        assert_eq!(scalar.unquoted_value(), "\"");
+
+        let (doc, _) = Document::from_str_relaxed("'");
+        let scalar = doc.as_scalar().expect("relaxed parse keeps a scalar");
+        assert_eq!(scalar.as_string(), "'");
+        assert_eq!(scalar.unquoted_value(), "'");
+    }
 
     #[test]
     fn test_json_array_quoted_strings_cst_structure() {


### PR DESCRIPTION
## Summary

`Scalar::as_string` and `unquoted_value` no longer panic on a one-character quote from a relaxed parse.

## Problem

The lexer emits `UNTERMINATED_STRING` with text `"` or `'`. Strict `from_str` errors. `from_str_relaxed` returns a usable tree (documented). Then `as_string()` sliced `[1..0]`.

## Change

Treat the text as quoted only when `len() >= 2`. A lone quote stays as raw text.

## Validation

```
Red:  cargo test --lib test_unterminated_quote_as_string_does_not_panic
      panic: byte range starts at 1 but ends at 0
Green: same test, ok
```

## Origin

Present since [`3c9b46e`](https://github.com/jelmer/yaml-edit/commit/3c9b46e) (2026-02-25).
