### PR TITLE
fix: insert_after returns false when the reference key is missing

### DIFF
--- a/src/nodes/mapping.rs
+++ b/src/nodes/mapping.rs
@@ -2705,7 +2705,7 @@ impl Mapping {
         // Check if the new key already exists - if so, just update it
         if self.find_entry_by_key(&key).is_some() {
             self.set_as_yaml(&key, &value);
-            return true;
+            return self.find_entry_by_key(&after_key).is_some();
         }
 
         // Key doesn't exist yet - delegate to move_after, which already contains
@@ -2955,6 +2955,23 @@ mod tests {
         assert_eq!(
             reparsed.as_mapping().unwrap().get("foo").unwrap().kind(),
             YamlKind::Mapping
+        );
+    }
+
+    #[test]
+    fn test_insert_after_existing_key_missing_ref_returns_false() {
+        use crate::yaml::Document;
+        let doc = Document::from_str("a: 1\nb: 2\n").unwrap();
+        let mapping = doc.as_mapping().unwrap();
+        assert!(!mapping.insert_after("missing", "a", "99"));
+        assert_eq!(
+            mapping.get("a").unwrap().as_scalar().unwrap().as_string(),
+            "99"
+        );
+        assert!(!mapping.insert_before("missing", "b", "88"));
+        assert_eq!(
+            mapping.get("b").unwrap().as_scalar().unwrap().as_string(),
+            "88"
         );
     }
 


### PR DESCRIPTION
## Summary

`insert_after` now returns `false` when the reference key is missing, matching `insert_before` and the docs.

## Problem

Both methods say they return false only if the reference key is not found. If `key` already exists, `insert_after` updated the value and returned `true` without checking `after_key`. `insert_before` already checked `before_key`.

## Change

The existing-key path in `insert_after` returns `find_entry_by_key(&after_key).is_some()`.

## Validation

```
Red:  cargo test --lib test_insert_after_existing_key_missing_ref_returns_false
      assertion failed: !mapping.insert_after("missing", "a", "99")
Green: same test, ok
```

## Origin

Present since [`3c9b46e`](https://github.com/jelmer/yaml-edit/commit/3c9b46e) (2026-02-25).
