### PR TITLE
fix: emit an implicit-null scalar for a bare sequence dash

### DIFF
--- a/src/nodes/sequence.rs
+++ b/src/nodes/sequence.rs
@@ -1048,6 +1048,30 @@ mod tests {
     }
 
     #[test]
+    fn test_implicit_null_item_shares_indexes_with_set_and_remove() {
+        use crate::Document;
+        let doc = Document::from_str("- a\n- \n- c\n").unwrap();
+        let seq = doc.as_sequence().unwrap();
+        assert_eq!(seq.len(), 3);
+        assert_eq!(seq.get(0).unwrap().as_scalar().unwrap().as_string(), "a");
+        assert_eq!(seq.get(1).unwrap().as_scalar().unwrap().as_string(), "");
+        assert_eq!(seq.get(2).unwrap().as_scalar().unwrap().as_string(), "c");
+
+        assert!(seq.set(1, "x"));
+        assert_eq!(doc.to_string(), "- a\n- x\n- c\n");
+
+        let doc = Document::from_str("- a\n- \n- c\n").unwrap();
+        let seq = doc.as_sequence().unwrap();
+        let removed = seq.remove(1);
+        assert_eq!(
+            removed.and_then(|n| n.as_scalar().map(|s| s.as_string())),
+            Some(String::new())
+        );
+        assert_eq!(seq.len(), 2);
+        assert_eq!(seq.get(1).unwrap().as_scalar().unwrap().as_string(), "c");
+    }
+
+    #[test]
     fn test_sequence_items_tagged_node() {
         // Tagged scalars inside sequences were previously skipped by items() because
         // TAGGED_NODE was not listed in the kind filter.

--- a/src/nodes/sequence.rs
+++ b/src/nodes/sequence.rs
@@ -1069,6 +1069,12 @@ mod tests {
         );
         assert_eq!(seq.len(), 2);
         assert_eq!(seq.get(1).unwrap().as_scalar().unwrap().as_string(), "c");
+
+        let doc = Document::from_str("- a\n-\n- c\n").unwrap();
+        let seq = doc.as_sequence().unwrap();
+        assert_eq!(seq.len(), 3);
+        assert!(seq.set(1, "x"));
+        assert_eq!(doc.to_string(), "- a\n-x\n- c\n");
     }
 
     #[test]

--- a/src/nodes/sequence.rs
+++ b/src/nodes/sequence.rs
@@ -641,6 +641,7 @@ impl Sequence {
 
                         let mut value_inserted = false;
                         let mut trailing_text: Option<String> = None;
+                        let mut after_dash = false;
 
                         for entry_child in entry_children {
                             match &entry_child {
@@ -663,17 +664,26 @@ impl Sequence {
 
                                     // Replace the value node with the new value built from AsYaml
                                     if !value_inserted {
+                                        // A bare `-` item is DASH then a zero-width NULL
+                                        // scalar. Insert the space that a written value
+                                        // needs so set does not serialize as `-x`.
+                                        if after_dash {
+                                            builder.token(SyntaxKind::WHITESPACE.into(), " ");
+                                        }
                                         value.build_content(&mut builder, 0, false);
                                         value_inserted = true;
                                     }
+                                    after_dash = false;
                                 }
                                 rowan::NodeOrToken::Node(n) => {
                                     // Copy other nodes as-is (like VALUE wrappers, etc.)
                                     crate::yaml::copy_node_to_builder(&mut builder, n);
+                                    after_dash = false;
                                 }
                                 rowan::NodeOrToken::Token(t) => {
                                     // Copy tokens as-is
                                     builder.token(t.kind().into(), t.text());
+                                    after_dash = t.kind() == SyntaxKind::DASH;
                                 }
                             }
                         }
@@ -1074,7 +1084,7 @@ mod tests {
         let seq = doc.as_sequence().unwrap();
         assert_eq!(seq.len(), 3);
         assert!(seq.set(1, "x"));
-        assert_eq!(doc.to_string(), "- a\n-x\n- c\n");
+        assert_eq!(doc.to_string(), "- a\n- x\n- c\n");
     }
 
     #[test]

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -1817,14 +1817,23 @@ impl Parser {
                 // Use item's line indent so nested mappings parse at the right level
                 self.parse_value_with_base_indent(item_indent);
             } else if self.current() == Some(SyntaxKind::NEWLINE) {
-                // Check if next line is indented (nested content for sequence item)
-                self.bump(); // consume newline
-                if self.current() == Some(SyntaxKind::INDENT) {
+                // Nested content is a NEWLINE then INDENT. A bare `-` item is
+                // an implicit null; leave the NEWLINE for the terminator bump
+                // so set/remove see DASH, SCALAR, NEWLINE in that order.
+                if self.upcoming_tokens().next() == Some(SyntaxKind::INDENT) {
+                    self.bump(); // consume newline
                     let indent_level = self.tokens.last().map(|(_, text)| text.len()).unwrap_or(0);
                     self.bump(); // consume indent
-                                 // Parse the indented content as the sequence item value
                     self.parse_value_with_base_indent(indent_level);
+                } else {
+                    self.builder.start_node(SyntaxKind::SCALAR.into());
+                    self.builder.token(SyntaxKind::NULL.into(), "");
+                    self.builder.finish_node();
                 }
+            } else {
+                self.builder.start_node(SyntaxKind::SCALAR.into());
+                self.builder.token(SyntaxKind::NULL.into(), "");
+                self.builder.finish_node();
             }
 
             // Block-style SEQUENCE_ENTRY owns its NEWLINE terminator (DESIGN.md)


### PR DESCRIPTION
## Summary

A bare `-` sequence item is now an implicit-null scalar, so `len` / `get` / `set` / `remove` share the same indexes.

## Problem

The parser left a `SEQUENCE_ENTRY` with no value node. `len` and `get` skipped those entries. `set` and `remove` counted every entry. On `- a` / `-` / `- c`:

- `get(1)` was `c`
- `set(1, "x")` returned true and wrote nothing
- `set(2, "x")` replaced `c` even though `get(2)` was `None`
- `remove(1)` returned `c` but deleted the hidden null

Mappings already emit an implicit-null `SCALAR` for a missing value.

## Change

If a block sequence item is only a dash (no nested INDENT after the newline), emit `SCALAR { NULL "" }` and leave the NEWLINE as the entry terminator.

## Validation

```
Red:  cargo test --lib test_implicit_null_item_shares_indexes_with_set_and_remove
      len() was 2, expected 3
Green: same test, ok
      cargo test --lib nodes::sequence::tests  (50 passed)
```

## Origin

Present since [`3c9b46e`](https://github.com/jelmer/yaml-edit/commit/3c9b46e) (2026-02-25).
