### PR TITLE
fix: insert flow sequence items inside the brackets

### DIFF
--- a/src/nodes/sequence.rs
+++ b/src/nodes/sequence.rs
@@ -179,10 +179,62 @@ impl Sequence {
             .unwrap_or_else(|| "  ".to_string())
     }
 
+    fn insert_flow_item(&self, index: usize, value: impl crate::AsYaml) {
+        let mut builder = GreenNodeBuilder::new();
+        builder.start_node(SyntaxKind::SEQUENCE_ENTRY.into());
+        value.build_content(&mut builder, 0, false);
+        builder.finish_node();
+        let new_entry = SyntaxNode::new_root_mut(builder.finish());
+
+        let children: Vec<_> = self.0.children_with_tokens().collect();
+        let mut entry_positions = Vec::new();
+        let mut rbracket = None;
+        for (i, child) in children.iter().enumerate() {
+            if child
+                .as_node()
+                .is_some_and(|n| n.kind() == SyntaxKind::SEQUENCE_ENTRY)
+            {
+                entry_positions.push(i);
+            }
+            if child
+                .as_token()
+                .is_some_and(|t| t.kind() == SyntaxKind::RIGHT_BRACKET)
+            {
+                rbracket = Some(i);
+            }
+        }
+
+        let actual = index.min(entry_positions.len());
+        let insert_pos = if actual < entry_positions.len() {
+            entry_positions[actual]
+        } else {
+            rbracket.unwrap_or(children.len())
+        };
+
+        let has_prev = actual > 0;
+        let has_next = actual < entry_positions.len();
+        let mut elems = Vec::new();
+        if has_prev && !has_next {
+            elems.push(fresh_token(SyntaxKind::COMMA, ",").into());
+            elems.push(fresh_token(SyntaxKind::WHITESPACE, " ").into());
+        }
+        elems.push(new_entry.into());
+        if has_next {
+            elems.push(fresh_token(SyntaxKind::COMMA, ",").into());
+            elems.push(fresh_token(SyntaxKind::WHITESPACE, " ").into());
+        }
+
+        self.0.splice_children(insert_pos..insert_pos, elems);
+    }
+
     /// Add an item to the end of the sequence.
     ///
     /// Mutates in place despite `&self` (see crate docs on interior mutability).
     pub fn push(&self, value: impl crate::AsYaml) {
+        if self.is_flow_style() {
+            self.insert_flow_item(self.len(), value);
+            return;
+        }
         let indentation = self.detect_indentation();
 
         // Build the INDENT token (separate from the SEQUENCE_ENTRY)
@@ -296,6 +348,10 @@ impl Sequence {
     ///
     /// Mutates in place despite `&self` (see crate docs on interior mutability).
     pub fn insert(&self, index: usize, value: impl crate::AsYaml) {
+        if self.is_flow_style() {
+            self.insert_flow_item(index, value);
+            return;
+        }
         let indentation = self.detect_indentation();
 
         // Build the new SEQUENCE_ENTRY, terminated with its own NEWLINE.
@@ -1352,6 +1408,25 @@ scores:
 
         let values: Vec<String> = seq.values().map(|v| v.to_string()).collect();
         assert_eq!(values, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_flow_sequence_push_serializes_inside_brackets() {
+        use crate::Document;
+        let doc = Document::from_str("items: [a, b]\n").unwrap();
+        let seq = doc.get_sequence("items").unwrap();
+        seq.push("c");
+        assert_eq!(doc.to_string(), "items: [a, b, c]\n");
+
+        let doc = Document::from_str("items: []\n").unwrap();
+        let seq = doc.get_sequence("items").unwrap();
+        seq.push("c");
+        assert_eq!(doc.to_string(), "items: [c]\n");
+
+        let doc = Document::from_str("items: [b, c]\n").unwrap();
+        let seq = doc.get_sequence("items").unwrap();
+        seq.insert(0, "a");
+        assert_eq!(doc.to_string(), "items: [a, b, c]\n");
     }
 
     #[test]

--- a/src/nodes/sequence.rs
+++ b/src/nodes/sequence.rs
@@ -66,6 +66,31 @@ fn trailing_newline_indent(node: &SyntaxNode) -> Option<String> {
     Some(result)
 }
 
+fn append_comma_space_to_seq_entry(entry: &SyntaxNode) {
+    let ends_with_comma = entry
+        .children_with_tokens()
+        .filter_map(|c| c.into_token())
+        .filter(|t| {
+            !matches!(
+                t.kind(),
+                SyntaxKind::WHITESPACE | SyntaxKind::NEWLINE | SyntaxKind::INDENT
+            )
+        })
+        .last()
+        .is_some_and(|t| t.kind() == SyntaxKind::COMMA);
+    if ends_with_comma {
+        return;
+    }
+    let end = entry.children_with_tokens().count();
+    entry.splice_children(
+        end..end,
+        vec![
+            fresh_token(SyntaxKind::COMMA, ",").into(),
+            fresh_token(SyntaxKind::WHITESPACE, " ").into(),
+        ],
+    );
+}
+
 impl Sequence {
     /// Iterate over items in this sequence as raw syntax nodes.
     ///
@@ -213,18 +238,17 @@ impl Sequence {
 
         let has_prev = actual > 0;
         let has_next = actual < entry_positions.len();
-        let mut elems = Vec::new();
         if has_prev && !has_next {
-            elems.push(fresh_token(SyntaxKind::COMMA, ",").into());
-            elems.push(fresh_token(SyntaxKind::WHITESPACE, " ").into());
+            if let Some(prev) = children[entry_positions[actual - 1]].as_node() {
+                append_comma_space_to_seq_entry(prev);
+            }
         }
-        elems.push(new_entry.into());
         if has_next {
-            elems.push(fresh_token(SyntaxKind::COMMA, ",").into());
-            elems.push(fresh_token(SyntaxKind::WHITESPACE, " ").into());
+            append_comma_space_to_seq_entry(&new_entry);
         }
 
-        self.0.splice_children(insert_pos..insert_pos, elems);
+        self.0
+            .splice_children(insert_pos..insert_pos, vec![new_entry.into()]);
     }
 
     /// Add an item to the end of the sequence.


### PR DESCRIPTION
## Summary

`Sequence::push` and `insert` add a flow item inside `[]` instead of a block dash entry.

## Problem

`items: [a, b]` then `push("c")` serialized as `items: [a, b\n  - c]`. `is_flow_style()` existed but push always emitted `- `.

## Change

Flow sequences build a `SEQUENCE_ENTRY` without a dash, put `, ` inside the preceding (or new) entry like the parser and `Mapping::insert_flow_entry_cst_at`, and splice before `]`.

Open PR #2 special-cases empty `[]` only. This covers a non-empty flow list and the serialized form.

## Validation

```
Red:  cargo test --lib test_flow_sequence_push_serializes_inside_brackets
      left: "items: [a, b\n  - c]\n"
Green: same test plus existing flow sequence tests, ok
```

## Origin

Present since [`3c9b46e`](https://github.com/jelmer/yaml-edit/commit/3c9b46e) (2026-02-25). Related: open [#2](https://github.com/jelmer/yaml-edit/pull/2) (empty `[]` only).
