### PR TITLE
fix: leave mapping unchanged when move_after ref is missing

### DIFF
--- a/src/nodes/mapping/movements.rs
+++ b/src/nodes/mapping/movements.rs
@@ -24,6 +24,16 @@ impl Mapping {
         new_value: &impl crate::AsYaml,
         where_at: fn(SyntaxNode) -> FlowInsertPos,
     ) -> bool {
+        let Some(target) = self.find_entry_by_key(ref_key) else {
+            return false;
+        };
+        if self
+            .find_entry_by_key(new_key)
+            .is_some_and(|e| e.syntax() == target.syntax())
+        {
+            self.set(new_key, new_value);
+            return true;
+        }
         // Contract: move, not duplicate. Drop any prior entry with the
         // same key first.
         if let Some(existing) = self.find_entry_by_key(new_key) {
@@ -35,9 +45,6 @@ impl Mapping {
                 self.0.splice_children(idx..idx + 1, vec![]);
             }
         }
-        let Some(target) = self.find_entry_by_key(ref_key) else {
-            return false;
-        };
         let entry = MappingEntry::new_at_indent(
             new_key,
             new_value,
@@ -75,6 +82,16 @@ impl Mapping {
         new_key: impl crate::AsYaml,
         new_value: impl crate::AsYaml,
     ) -> bool {
+        let Some(target) = self.find_entry_by_key(&after_key) else {
+            return false;
+        };
+        if self
+            .find_entry_by_key(&new_key)
+            .is_some_and(|e| e.syntax() == target.syntax())
+        {
+            self.set(&new_key, &new_value);
+            return true;
+        }
         if self.is_flow_style() {
             return self.move_flow_around(&after_key, &new_key, &new_value, FlowInsertPos::After);
         }
@@ -349,6 +366,16 @@ impl Mapping {
         new_key: impl crate::AsYaml,
         new_value: impl crate::AsYaml,
     ) -> bool {
+        let Some(target) = self.find_entry_by_key(&before_key) else {
+            return false;
+        };
+        if self
+            .find_entry_by_key(&new_key)
+            .is_some_and(|e| e.syntax() == target.syntax())
+        {
+            self.set(&new_key, &new_value);
+            return true;
+        }
         if self.is_flow_style() {
             return self.move_flow_around(&before_key, &new_key, &new_value, FlowInsertPos::Before);
         }

--- a/src/nodes/mapping/tests.rs
+++ b/src/nodes/mapping/tests.rs
@@ -56,6 +56,24 @@ fn test_insert_after_existing_key_missing_ref_returns_false() {
     );
 }
 
+#[test]
+fn test_move_after_missing_ref_leaves_mapping_unchanged() {
+    use crate::yaml::Document;
+    let doc = Document::from_str("a: 1\nb: 2\n").unwrap();
+    let mapping = doc.as_mapping().unwrap();
+    assert!(!mapping.move_after("missing", "a", "3"));
+    assert_eq!(doc.to_string(), "a: 1\nb: 2\n");
+    assert!(!mapping.move_before("missing", "a", "3"));
+    assert_eq!(doc.to_string(), "a: 1\nb: 2\n");
+    assert!(mapping.move_after("a", "a", "3"));
+    assert_eq!(doc.to_string(), "a: '3'\nb: 2\n");
+
+    let doc = Document::from_str("{a: 1, b: 2}").unwrap();
+    let mapping = doc.as_mapping().unwrap();
+    assert!(!mapping.move_after("missing", "a", "3"));
+    assert_eq!(doc.to_string(), "{a: 1, b: 2}");
+}
+
 /// Setting into a flow-style mapping (`{...}`) inserts entries inside
 /// the braces with proper `, ` separators, not on new lines after `}`
 /// (which would produce broken YAML).


### PR DESCRIPTION
## Summary

`Mapping::move_after` and `move_before` now look up the anchor key before deleting `new_key`, so a missing ref returns `false` and leaves the mapping unchanged.

## Problem

The docs say a missing `after_key` / `before_key` returns `false` and does not change the mapping. The implementation deleted any existing `new_key` first, then looked up the ref.

```rust
let doc = Document::from_str("a: 1\nb: 2\n").unwrap();
let mapping = doc.as_mapping().unwrap();
assert!(!mapping.move_after("missing", "a", "3"));
// was: "b: 2\n"  (a was dropped)
// now: "a: 1\nb: 2\n"
```

Same on flow `{a: 1, b: 2}`. `move_after("a", "a", "3")` also dropped `a` because the delete removed the only copy of the anchor.

This is the same contract as `insert_after` after #62, on the move path.

## Change

- Resolve the anchor first. Missing ref: return `false`, no splice.
- Same-key move: `set` the value in place and return `true`.
- Different key: existing remove-then-insert path is unchanged.

## Validation

```
Red:  cargo test --lib test_move_after_missing_ref_leaves_mapping_unchanged
      FAIL  left: "b: 2\n"  right: "a: 1\nb: 2\n"
Green: same command  ok
clippy --all-targets --all-features -D warnings  ok
```

## Origin

The delete-first order landed in [#71](https://github.com/jelmer/yaml-edit/pull/71) ([`bc835e71`](https://github.com/jelmer/yaml-edit/commit/bc835e71), 2026-08-30) when `move_after` / `move_before` moved into `mapping/movements.rs`.

Related: [#62](https://github.com/jelmer/yaml-edit/pull/62) (`insert_after` missing ref).
