### PR TITLE
fix: do not replace a sequence root in Document::insert_at_index

### DIFF
--- a/src/nodes/document.rs
+++ b/src/nodes/document.rs
@@ -446,7 +446,7 @@ impl Document {
         builder.finish_node(); // VALUE
     }
 
-    /// Insert a key-value pair at a specific index (assumes document is a mapping).
+    /// Insert a key-value pair at a specific index.
     ///
     /// If the document already contains a mapping, delegates to
     /// [`Mapping::insert_at_index`]. If the document has no root node, creates

--- a/src/nodes/document.rs
+++ b/src/nodes/document.rs
@@ -449,8 +449,9 @@ impl Document {
     /// Insert a key-value pair at a specific index (assumes document is a mapping).
     ///
     /// If the document already contains a mapping, delegates to
-    /// [`Mapping::insert_at_index`]. If no mapping exists yet, creates one and
-    /// uses [`Mapping::insert_at_index_preserving`].
+    /// [`Mapping::insert_at_index`]. If the document has no root node, creates
+    /// a mapping and uses [`Mapping::insert_at_index_preserving`]. A sequence
+    /// or other non-mapping root is left unchanged.
     pub fn insert_at_index(
         &self,
         index: usize,
@@ -460,6 +461,12 @@ impl Document {
         // Delegate to Mapping::insert_at_index if we have a mapping
         if let Some(mapping) = self.as_mapping() {
             mapping.insert_at_index(index, key, value);
+            return;
+        }
+
+        // Sequence or scalar root: leave the document unchanged (same
+        // as Document::set).
+        if self.root_node().is_some() {
             return;
         }
 
@@ -1120,6 +1127,16 @@ active: true
             YamlFile::from_str(&output3).is_ok(),
             "Set output should be valid YAML"
         );
+    }
+
+    #[test]
+    fn test_insert_at_index_leaves_sequence_root() {
+        let doc = Document::from_str("- a\n- b\n").unwrap();
+        assert!(!doc.set("k", "v"));
+        assert_eq!(doc.to_string(), "- a\n- b\n");
+        doc.insert_at_index(0, "k", "v");
+        assert_eq!(doc.to_string(), "- a\n- b\n");
+        assert!(doc.as_sequence().is_some());
     }
 
     #[test]

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -705,8 +705,9 @@ impl YamlFile {
     ///
     /// Delegates to [`Document::insert_at_index`]. If `key` already exists it
     /// is updated in-place rather than moved. If `index` is out of bounds the
-    /// entry is appended at the end. If the document has no mapping yet, one is
-    /// created automatically. This method always succeeds; it never returns an error.
+    /// entry is appended at the end. If the first document has no root node,
+    /// a mapping is created. A sequence or other non-mapping root is left
+    /// unchanged.
     ///
     /// Mutates in place despite `&self` (see crate docs on interior mutability).
     pub fn insert_at_index(


### PR DESCRIPTION
## Summary

`Document::insert_at_index` now leaves a sequence or scalar root unchanged, matching `Document::set` after #61.

## Problem

`Document::set` returns `false` and does not rewrite a sequence root. `insert_at_index` treated any non-mapping root as "no mapping yet" and spliced a new mapping over the whole document.

```rust
let doc = Document::from_str("- a\n- b\n").unwrap();
assert!(!doc.set("k", "v"));          // still "- a\n- b\n"
doc.insert_at_index(0, "k", "v");     // was: "---\nk: v\n"
```

Empty documents still get a new mapping (`tests/insert_index_tests.rs` `test_insert_at_index_empty_document`).

## Change

If `as_mapping()` is `None` and `root_node()` is `Some`, return without splicing. Signature stays `()` (no `bool`, no `Result`).

## Validation

```
Red:  cargo test --lib test_insert_at_index_leaves_sequence_root
      FAIL  left: "---\nk: v\n"  right: "- a\n- b\n"
Green: same command  ok
cargo test --test insert_index_tests  8 passed
clippy --all-targets --all-features -D warnings  ok
```

## Origin

`insert_at_index` has replaced a missing mapping since [`3c9b46e`](https://github.com/jelmer/yaml-edit/commit/3c9b46eaecd4f078d9223dfd1ca56b94f8b59097) (2026-02-25). [#61](https://github.com/jelmer/yaml-edit/pull/61) taught `set` to refuse a sequence root; this method was not updated.
