### PR TITLE
fix: preserve anchored values and plain scalar content

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -255,16 +255,11 @@ impl From<SyntaxKind> for rowan::SyntaxKind {
 /// plain scalar or a real terminator. Internal whitespace is followed by
 /// more plain-scalar content on the same line; a terminator is followed by
 /// end-of-line, end-of-input, a `#` comment marker, a `:` that ends the
-/// scalar (colon + whitespace/EOF), a flow indicator, or any other YAML
-/// special character.
-///
-/// Whitespace before a flow indicator is treated as a terminator even in
-/// block context: while the main loop treats `[](){},` as scalar content
-/// when they appear directly (no leading space), a space introduces a
-/// clear boundary that should be preserved as its own WHITESPACE token.
+/// scalar, or a structural indicator. Quotes and hyphens remain scalar
+/// content here; flow delimiters terminate only in flow context.
 ///
 /// Caller must guarantee the character at `ws_idx` is a space or tab.
-fn plain_scalar_continues_past_whitespace(input: &str, ws_idx: usize, _flow_depth: u32) -> bool {
+fn plain_scalar_continues_past_whitespace(input: &str, ws_idx: usize, flow_depth: u32) -> bool {
     let rest = &input[ws_idx..];
     // Find the first non-whitespace char in the run.
     let (offset, next) = match rest.char_indices().find(|(_, c)| *c != ' ' && *c != '\t') {
@@ -273,15 +268,9 @@ fn plain_scalar_continues_past_whitespace(input: &str, ws_idx: usize, _flow_dept
     };
     match next {
         '\n' | '\r' | '#' => false,
-        ',' | '[' | ']' | '{' | '}' => false,
-        ':' => {
-            let colon_pos = ws_idx + offset;
-            let after_colon = &input[colon_pos + 1..];
-            after_colon
-                .chars()
-                .next()
-                .is_some_and(|nc| !nc.is_whitespace())
-        }
+        ',' | '[' | ']' | '{' | '}' if flow_depth > 0 => false,
+        ':' => !is_colon_a_mapping_indicator(input, ws_idx + offset, flow_depth),
+        '-' | '\'' | '"' | ',' | '[' | ']' | '{' | '}' => true,
         c if is_yaml_special(c) => false,
         _ => true,
     }
@@ -360,7 +349,7 @@ fn read_plain_scalar_body_from<'a>(
 ) -> &'a str {
     let mut end_idx = start_idx;
     while let Some((idx, ch)) = chars.peek().copied() {
-        if ch == '\n' || ch == '\r' || ch.is_whitespace() {
+        if ch.is_whitespace() {
             break;
         }
         if ch == ':' && is_colon_a_mapping_indicator(input, idx, flow_depth) {
@@ -369,7 +358,9 @@ fn read_plain_scalar_body_from<'a>(
         if ch == '#' && is_hash_a_comment_start(input, idx) {
             break;
         }
-        if ch != ':' && ch != '-' && ch != '#' && is_yaml_special(ch) {
+        if is_yaml_special_except(ch, "-:#'\"")
+            && !(flow_depth == 0 && matches!(ch, ',' | '[' | ']' | '{' | '}'))
+        {
             break;
         }
         end_idx = idx + ch.len_utf8();
@@ -430,6 +421,7 @@ pub fn lex_with_validation_config<'a>(
     if let Some((0, '\u{FEFF}')) = chars.peek() {
         chars.next(); // Consume the BOM
         tokens.push((BOM, "\u{FEFF}"));
+        current_line_start = '\u{FEFF}'.len_utf8();
     }
 
     while let Some((start_idx, ch)) = chars.next() {
@@ -438,16 +430,17 @@ pub fn lex_with_validation_config<'a>(
         match ch {
             // Context-aware hyphen handling
             '-' => {
-                if let Some((_, '-')) = chars.peek() {
-                    chars.next(); // consume second -
-                    if let Some((_, '-')) = chars.peek() {
-                        chars.next(); // consume third -
-                        tokens.push((DOC_START, &input[token_start..start_idx + 3]));
-                    } else {
-                        // Just two dashes, treat as sequence marker followed by dash
-                        tokens.push((DASH, &input[token_start..start_idx + 1]));
-                        tokens.push((DASH, &input[start_idx + 1..start_idx + 2]));
-                    }
+                if flow_depth == 0
+                    && start_idx == current_line_start
+                    && input[start_idx..].starts_with("---")
+                    && input[start_idx + 3..]
+                        .chars()
+                        .next()
+                        .map_or(true, |next| next.is_whitespace())
+                {
+                    chars.next();
+                    chars.next();
+                    tokens.push((DOC_START, &input[token_start..start_idx + 3]));
                 } else {
                     // Check if this hyphen should be treated as a sequence marker
                     // It's a sequence marker if:
@@ -971,7 +964,7 @@ pub fn lex_with_validation_config<'a>(
                     // are inside a plain-scalar body they are ordinary content
                     // per YAML 1.2 §7.1 (a `&anchor` must be followed by
                     // whitespace to actually be an anchor).
-                    if is_yaml_special_except(next_ch, "-:#&*!?") {
+                    if is_yaml_special_except(next_ch, "-:#&*!?'\">") {
                         // In block context, flow indicators do NOT break scalars
                         if flow_depth == 0 && matches!(next_ch, '[' | ']' | '{' | '}' | ',') {
                             // do nothing, let it be part of the scalar
@@ -1496,15 +1489,9 @@ double: "quoted""#;
         let input = "line with - and + and : characters";
         let tokens = lex(input);
 
-        // Plain scalars absorb intra-line whitespace until they hit a real
-        // terminator, so `line with` is one STRING and the standalone `-`
-        // between spaces is another (not a sequence marker mid-line).
         assert!(tokens
             .iter()
-            .any(|(kind, text)| *kind == SyntaxKind::STRING && *text == "line with"));
-        assert!(tokens
-            .iter()
-            .any(|(kind, text)| *kind == SyntaxKind::STRING && *text == "-"));
+            .any(|(kind, text)| *kind == SyntaxKind::STRING && *text == "line with - and"));
 
         // Plus and colon remain separately tokenized.
         assert!(tokens
@@ -1543,11 +1530,10 @@ double: "quoted""#;
                                                   // Multiple STRING tokens: "key", content words, and the hyphen
         assert!(count(SyntaxKind::STRING) >= 1, "expected STRING tokens");
 
-        // With context-aware hyphen parsing, the hyphen in content is now part of a STRING
         assert_eq!(
             tokens
                 .iter()
-                .filter(|(kind, text)| *kind == SyntaxKind::STRING && *text == "-")
+                .filter(|(kind, text)| *kind == SyntaxKind::STRING && *text == "content with - and")
                 .count(),
             1
         );
@@ -1569,15 +1555,12 @@ double: "quoted""#;
         // Test 3: Two dashes (not a document marker)
         let input = "--";
         let tokens = lex(input);
-        assert_eq!(tokens.len(), 2);
-        assert_eq!(tokens[0], (SyntaxKind::DASH, "-"));
-        assert_eq!(tokens[1], (SyntaxKind::DASH, "-"));
+        assert_eq!(tokens, vec![(SyntaxKind::STRING, "--")]);
 
         // Test 4: Four dashes
         let input = "----";
         let tokens = lex(input);
-        assert_eq!(tokens[0], (SyntaxKind::DOC_START, "---"));
-        assert_eq!(tokens[1], (SyntaxKind::STRING, "-"));
+        assert_eq!(tokens, vec![(SyntaxKind::STRING, "----")]);
     }
 
     #[test]
@@ -1602,18 +1585,8 @@ double: "quoted""#;
         // Test command-line arguments
         let input = "args: --verbose --log-level=debug";
         let tokens = lex(input);
-        // Double dashes are tokenized as two DASH tokens
-        assert_eq!(
-            tokens
-                .windows(3)
-                .filter(|w| {
-                    w[0] == (SyntaxKind::DASH, "-")
-                        && w[1] == (SyntaxKind::DASH, "-")
-                        && w[2] == (SyntaxKind::STRING, "verbose")
-                })
-                .count(),
-            1
-        );
+        assert_eq!(tokens[3], (SyntaxKind::STRING, "--verbose"));
+        assert_eq!(tokens[5], (SyntaxKind::STRING, "--log-level=debug"));
 
         // Test negative numbers
         let input = "temperature: -40";

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -661,11 +661,6 @@ impl Parser {
         // it's clearly a structured value, otherwise parse as scalar.
         match self.current() {
             Some(SyntaxKind::DASH) if !self.in_flow_context => self.parse_sequence(),
-            Some(SyntaxKind::ANCHOR) => {
-                self.bump(); // consume and emit anchor token to CST
-                self.skip_whitespace();
-                self.parse_value_with_base_indent(0);
-            }
             Some(SyntaxKind::REFERENCE) => self.parse_alias(),
             Some(SyntaxKind::TAG) => self.parse_tagged_value(),
             Some(SyntaxKind::QUESTION) => {
@@ -790,6 +785,14 @@ impl Parser {
 
             // Parse value - wrap in VALUE node
             self.builder.start_node(SyntaxKind::VALUE.into());
+            // Anchors annotate the value; they do not make a following block value inline.
+            while self.current() == Some(SyntaxKind::ANCHOR) {
+                self.bump();
+                self.skip_whitespace();
+            }
+            if self.current() == Some(SyntaxKind::COMMENT) {
+                self.bump();
+            }
             let mut has_value = false;
             if self.current().is_some()
                 && self.current() != Some(SyntaxKind::NEWLINE)
@@ -807,24 +810,6 @@ impl Parser {
                 if self.current() == Some(SyntaxKind::COMMENT) {
                     self.bump(); // emit inline comment inside VALUE
                 }
-            } else if self.current() == Some(SyntaxKind::COMMENT) {
-                // Comment after colon with no inline value
-                // The comment belongs to the VALUE, and any indented content after it
-                // also belongs to this VALUE (e.g., "key:  # comment\n  nested: value")
-                self.bump(); // consume comment inside VALUE
-
-                if self.current() == Some(SyntaxKind::NEWLINE) {
-                    self.bump(); // consume newline inside VALUE
-
-                    if self.current() == Some(SyntaxKind::INDENT) {
-                        let indent_level = self.tokens.last().map_or(0, |(_, text)| text.len());
-                        self.bump(); // consume indent inside VALUE
-                                     // Parse the indented content as part of this VALUE
-                        self.parse_value_with_base_indent(indent_level);
-                        has_value = true;
-                    }
-                }
-                // If no indented content follows the comment, has_value stays false → implicit null
             } else if self.current() == Some(SyntaxKind::NEWLINE) {
                 self.skip_ws_and_newlines();
                 if self.current_line_indent > base_indent {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -270,8 +270,13 @@ impl Parser {
                 }
             }
             Some(SyntaxKind::MERGE_KEY) => {
-                // Merge key is always a mapping
-                self.parse_mapping_with_base_indent(base_indent);
+                if self.in_flow_context {
+                    self.builder.start_node(SyntaxKind::SCALAR.into());
+                    self.bump();
+                    self.builder.finish_node();
+                } else {
+                    self.parse_mapping_with_base_indent(base_indent);
+                }
             }
             Some(SyntaxKind::QUESTION) => {
                 // Explicit key indicator - parse complex mapping

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -4187,16 +4187,14 @@ server:
 
     // Tests for next_flow_element_is_implicit_mapping lookahead function
     mod lookahead_tests {
-        use super::*;
         use crate::lex::lex;
         use crate::parser::has_implicit_mapping_pattern;
 
         /// Helper to test lookahead without creating full parser
         fn check_implicit_mapping(yaml: &str) -> bool {
-            let tokens: Vec<(SyntaxKind, &str)> = lex(yaml);
-            // Extract just the kinds in reverse order (matching Parser's token storage)
-            let kinds: Vec<SyntaxKind> = tokens.iter().rev().map(|(kind, _)| *kind).collect();
-            has_implicit_mapping_pattern(kinds.into_iter())
+            let flow = format!("[{yaml}]");
+            let tokens = lex(&flow);
+            has_implicit_mapping_pattern(tokens[1..tokens.len() - 1].iter().map(|(kind, _)| *kind))
         }
 
         #[test]

--- a/tests/anchor_mapping_preservation_test.rs
+++ b/tests/anchor_mapping_preservation_test.rs
@@ -1,0 +1,90 @@
+mod common;
+
+use rowan::ast::AstNode;
+use std::str::FromStr;
+use yaml_edit::{debug, YamlFile};
+
+#[test]
+fn anchored_indentless_sequence_preserves_sibling_mapping_and_edits() {
+    for indent in ["", "  "] {
+        for comment in ["", " # shared tags"] {
+            let yaml = format!(
+            "tags: &id001{comment}\n{indent}- engineering\nmetadata:\n  version: 0.1.0 # keep version comment\n  status: draft\n  tags: *id001\n"
+        );
+            let file = YamlFile::from_str(&yaml).unwrap();
+            assert_eq!(file.to_string(), yaml);
+            let doc = file.document().unwrap();
+            let mapping = doc.as_mapping().unwrap();
+            assert_eq!(
+                mapping.keys().count(),
+                2,
+                "{}",
+                debug::tree_to_string(file.syntax())
+            );
+            let tags = mapping.get("tags").unwrap();
+            let tags = tags.as_sequence().unwrap();
+            assert_eq!(tags.len(), 1);
+            assert_eq!(
+                tags.get(0).unwrap().as_scalar().unwrap().as_string(),
+                "engineering"
+            );
+            let metadata = mapping.get_mapping("metadata").unwrap();
+            assert_eq!(
+                metadata.get("tags").unwrap().as_alias().unwrap().name(),
+                "id001"
+            );
+            metadata.set("version", "0.1.1");
+            common::assert_file_cst_ok(&file);
+            assert_eq!(
+                file.to_string(),
+                yaml.replace("version: 0.1.0", "version: 0.1.1")
+            );
+            metadata.set("status", "stable");
+            common::assert_file_cst_ok(&file);
+            assert_eq!(
+                file.to_string(),
+                yaml.replace("version: 0.1.0", "version: 0.1.1")
+                    .replace("status: draft", "status: stable")
+            );
+        }
+    }
+}
+
+#[test]
+fn flow_merge_alias_preserves_following_entry_and_metadata_edits() {
+    for separator in [", ", " , "] {
+        let yaml = format!(
+            "x: &defaults {{a: 3}}\ny: {{<<: *defaults{separator}more: 'kept'}}\nmetadata:\n  version: 0.1.0\n  status: draft # keep status comment\n"
+        );
+        let file = YamlFile::from_str(&yaml).unwrap();
+        assert_eq!(file.to_string(), yaml);
+        let root = file.document().unwrap().as_mapping().unwrap();
+        assert_eq!(root.keys().count(), 3);
+        let merged = root.get_mapping("y").unwrap();
+        assert_eq!(merged.keys().count(), 2);
+        let merge_key = merged.keys().next().unwrap();
+        assert_eq!(merge_key.as_scalar().unwrap().as_string(), "<<");
+        assert_eq!(
+            merged.get(&merge_key).unwrap().as_alias().unwrap().name(),
+            "defaults"
+        );
+        assert_eq!(
+            merged.get("more").unwrap().as_scalar().unwrap().as_string(),
+            "kept"
+        );
+        let metadata = root.get_mapping("metadata").unwrap();
+        metadata.set("version", "0.1.1");
+        common::assert_file_cst_ok(&file);
+        assert_eq!(
+            file.to_string(),
+            yaml.replace("version: 0.1.0", "version: 0.1.1")
+        );
+        metadata.set("status", "stable");
+        common::assert_file_cst_ok(&file);
+        assert_eq!(
+            file.to_string(),
+            yaml.replace("version: 0.1.0", "version: 0.1.1")
+                .replace("status: draft", "status: stable")
+        );
+    }
+}

--- a/tests/plain_scalar_preservation_test.rs
+++ b/tests/plain_scalar_preservation_test.rs
@@ -1,0 +1,172 @@
+mod common;
+
+use std::str::FromStr;
+use yaml_edit::{Mapping, YamlFile};
+
+fn assert_metadata_edits(file: &YamlFile, mapping: &Mapping, yaml: &str) {
+    assert_eq!(file.to_string(), yaml);
+    common::assert_file_cst_ok(file);
+    let metadata = mapping.get_mapping("metadata").unwrap();
+    metadata.set("version", "0.1.1");
+    common::assert_file_cst_ok(file);
+    assert_eq!(
+        file.to_string(),
+        yaml.replace("version: 0.1.0", "version: 0.1.1")
+    );
+    metadata.set("status", "released");
+    common::assert_file_cst_ok(file);
+    assert_eq!(
+        file.to_string(),
+        yaml.replace("version: 0.1.0", "version: 0.1.1")
+            .replace("status: draft", "status: released")
+    );
+}
+
+fn assert_plain_description(value: &str) {
+    let yaml =
+        format!("description: {value}\nmetadata:\n  version: 0.1.0 # keep\n  status: draft\n");
+    let file = YamlFile::from_str(&yaml).unwrap();
+    let mapping = file.document().unwrap().as_mapping().unwrap();
+    assert_eq!(
+        mapping
+            .get("description")
+            .unwrap()
+            .as_scalar()
+            .unwrap()
+            .as_string(),
+        value
+    );
+    assert_metadata_edits(&file, &mapping, &yaml);
+}
+
+#[test]
+fn embedded_quotes_remain_plain_scalar_content() {
+    for value in [
+        "author's machine",
+        "site's readiness",
+        "uses \"quoted words\" here",
+        "uses 'single quotes' here",
+    ] {
+        assert_plain_description(value);
+    }
+}
+
+#[test]
+fn block_text_keeps_commas_after_command_flags() {
+    for value in [
+        "follows sh -c, python3 -c and @resource files, and reports",
+        "-c, python3",
+        "--verbose, --log-level=debug",
+    ] {
+        assert_plain_description(value);
+    }
+}
+
+#[test]
+fn block_text_keeps_embedded_json_after_whitespace() {
+    for value in [
+        r#"Shape is {"entries":[{"name":"..."}]}."#,
+        r#"call query-trends {"kind":"TrendsQuery"}"#,
+        "text [one, two] follows",
+    ] {
+        assert_plain_description(value);
+    }
+}
+
+#[test]
+fn block_text_keeps_angle_brackets_before_commas() {
+    assert_plain_description("Absolute path to a directory for the capture, the composition and the MP4. It is created if missing. Leave it out and it lands under ~/launch-video/<site>, never in the play run workspace, which is deleted when the run ends.");
+}
+
+#[test]
+fn folded_scalar_indicator_and_flow_delimiters_stay_structural() {
+    let yaml = "folded: >-\n  first line\n  second line\nflow: [~/launch-video/<site>, kept]\nmetadata:\n  version: 0.1.0\n  status: draft\n";
+    let file = YamlFile::from_str(yaml).unwrap();
+    let mapping = file.document().unwrap().as_mapping().unwrap();
+    assert_eq!(
+        mapping
+            .get("folded")
+            .unwrap()
+            .as_scalar()
+            .unwrap()
+            .as_string(),
+        "first line second line"
+    );
+    let flow = mapping.get_sequence("flow").unwrap();
+    assert_eq!(flow.len(), 2);
+    assert_eq!(
+        flow.get(0).unwrap().as_scalar().unwrap().as_string(),
+        "~/launch-video/<site>"
+    );
+    assert_eq!(
+        flow.get(1).unwrap().as_scalar().unwrap().as_string(),
+        "kept"
+    );
+    assert_metadata_edits(&file, &mapping, yaml);
+}
+
+#[test]
+fn flow_sequence_keeps_double_dash_flags_as_scalars() {
+    let yaml = "argv: [python3, '@resource{traps.py}', $project, --validate, -c, --probe]\nmetadata:\n  version: 0.1.0\n  status: draft\n";
+    let file = YamlFile::from_str(yaml).unwrap();
+    let mapping = file.document().unwrap().as_mapping().unwrap();
+    let argv = mapping.get_sequence("argv").unwrap();
+    let expected = [
+        "python3",
+        "@resource{traps.py}",
+        "$project",
+        "--validate",
+        "-c",
+        "--probe",
+    ];
+    assert_eq!(argv.len(), expected.len());
+    for (index, expected) in expected.into_iter().enumerate() {
+        assert_eq!(
+            argv.get(index).unwrap().as_scalar().unwrap().as_string(),
+            expected
+        );
+    }
+    assert_metadata_edits(&file, &mapping, yaml);
+}
+
+#[test]
+fn real_quotes_flow_delimiters_and_document_markers_stay_structural() {
+    let yaml = "---\nquoted: 'author''s machine'\ndouble: \"quoted words\"\nflow: {list: [one, two], flag: --validate}\nblock:\n- --validate\n- ---not-a-marker\nmetadata:\n  version: 0.1.0\n  status: draft\n...\n---\nother: kept\n";
+    let file = YamlFile::from_str(yaml).unwrap();
+    assert_eq!(file.documents().count(), 2);
+    let mapping = file.document().unwrap().as_mapping().unwrap();
+    assert_eq!(
+        mapping
+            .get("quoted")
+            .unwrap()
+            .as_scalar()
+            .unwrap()
+            .as_string(),
+        "author's machine"
+    );
+    assert_eq!(
+        mapping
+            .get("double")
+            .unwrap()
+            .as_scalar()
+            .unwrap()
+            .as_string(),
+        "quoted words"
+    );
+    let flow = mapping.get_mapping("flow").unwrap();
+    assert_eq!(flow.len(), 2);
+    let list = flow.get_sequence("list").unwrap();
+    assert_eq!(list.len(), 2);
+    assert_eq!(list.get(1).unwrap().as_scalar().unwrap().as_string(), "two");
+    assert_eq!(
+        flow.get("flag").unwrap().as_scalar().unwrap().as_string(),
+        "--validate"
+    );
+    let block = mapping.get_sequence("block").unwrap();
+    assert_eq!(block.len(), 2);
+    assert_eq!(
+        block.get(1).unwrap().as_scalar().unwrap().as_string(),
+        "---not-a-marker"
+    );
+    assert_metadata_edits(&file, &mapping, yaml);
+}


### PR DESCRIPTION
Valid YAML can fail parsing or hide later mapping entries when it contains anchored block values, inline merge keys, or punctuation inside plain scalars. This prevents targeted edits even when the syntax tree retains the original bytes.

This change consumes anchors before choosing block versus inline parsing, leaves flow merge keys under flow-parser control, and keeps embedded quotes, block-context punctuation, and double-dash flags inside plain scalars. It also corrects the test-only implicit-mapping lookahead helper to use flow-context tokens in traversal order.

Regression tests check parsed values, sibling mapping lookup, exact round trips, targeted edits, and syntax-tree validity. Controls cover quoted values, flow collections, folded scalars, document markers, and block sequences.

## Verification

- Default and all-feature test suites pass, including doctests.
- Formatting and all-target, all-feature Clippy pass.

This PR contains only the parser fixes and tests. It does not include the downstream fork's package rename or publication metadata.