### PR TITLE
fix: treat a lone tag as annotating an indentless sequence

### DIFF
--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -790,6 +790,24 @@ impl Parser {
                 self.bump();
                 self.skip_whitespace();
             }
+            // A tag whose next content is an indentless `-` annotates that
+            // sequence (`key: !!seq\n- item`). Leave every other tag in
+            // place so parse_mapping_value can wrap a TAGGED_NODE
+            // (`!!int 42`, `!!set` plus an indented mapping).
+            if self.current() == Some(SyntaxKind::TAG) {
+                let upcoming: Vec<_> = self.upcoming_tokens().collect();
+                let newline_at = upcoming.iter().position(|k| *k == SyntaxKind::NEWLINE);
+                let rest_of_line_empty = upcoming
+                    .iter()
+                    .take(newline_at.unwrap_or(upcoming.len()))
+                    .all(|k| matches!(k, SyntaxKind::WHITESPACE | SyntaxKind::COMMENT));
+                let indentless_dash =
+                    newline_at.and_then(|i| upcoming.get(i + 1).copied()) == Some(SyntaxKind::DASH);
+                if rest_of_line_empty && indentless_dash {
+                    self.bump();
+                    self.skip_whitespace();
+                }
+            }
             if self.current() == Some(SyntaxKind::COMMENT) {
                 self.bump();
             }

--- a/tests/anchor_mapping_preservation_test.rs
+++ b/tests/anchor_mapping_preservation_test.rs
@@ -51,6 +51,58 @@ fn anchored_indentless_sequence_preserves_sibling_mapping_and_edits() {
 }
 
 #[test]
+fn tagged_indentless_sequence_preserves_sibling_mapping_and_edits() {
+    for tag in ["!!seq", "!keep"] {
+        let yaml = format!(
+            "tags: {tag}\n- engineering\nmetadata:\n  version: 0.1.0 # keep version comment\n  status: draft\n"
+        );
+        let file = YamlFile::from_str(&yaml).unwrap();
+        assert_eq!(file.to_string(), yaml);
+        let doc = file.document().unwrap();
+        let mapping = doc.as_mapping().unwrap();
+        assert_eq!(
+            mapping.keys().count(),
+            2,
+            "{}",
+            debug::tree_to_string(file.syntax())
+        );
+        let tags = mapping.get("tags").unwrap();
+        let tags = tags.as_sequence().unwrap();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(
+            tags.get(0).unwrap().as_scalar().unwrap().as_string(),
+            "engineering"
+        );
+        let metadata = mapping.get_mapping("metadata").unwrap();
+        metadata.set("version", "0.1.1");
+        common::assert_file_cst_ok(&file);
+        assert_eq!(
+            file.to_string(),
+            yaml.replace("version: 0.1.0", "version: 0.1.1")
+        );
+    }
+}
+
+#[test]
+fn tagged_inline_scalar_still_parses() {
+    let yaml = "count: !!int 42\nname: keep\n";
+    let file = YamlFile::from_str(yaml).unwrap();
+    assert_eq!(file.to_string(), yaml);
+    let mapping = file.document().unwrap().as_mapping().unwrap();
+    assert_eq!(mapping.keys().count(), 2);
+    assert_eq!(
+        mapping
+            .get("count")
+            .unwrap()
+            .as_tagged()
+            .unwrap()
+            .tag()
+            .as_deref(),
+        Some("!!int")
+    );
+}
+
+#[test]
 fn flow_merge_alias_preserves_following_entry_and_metadata_edits() {
     for separator in [", ", " , "] {
         let yaml = format!(


### PR DESCRIPTION
A mapping value that is only a tag, then an indentless sequence, was treated as an inline value. The tag became a tagged null and the following keys were leftover `ERROR` tokens with no parse error, so `from_str` succeeded and dropped those keys from `as_mapping()`.

```yaml
tags: !!seq
- engineering
metadata:
  version: 0.1.0
```

`YamlFile::from_str` succeeded. `keys().count()` was 1. PyYAML loads two keys. The same shape with `&id001` was fixed in #80 by skipping `ANCHOR` after the colon.

This skips `TAG` only when the next content is an indentless `-`. `!!int 42` and `!!set` plus an indented mapping still go through `parse_mapping_value` and keep a `TAGGED_NODE`.

The ANCHOR skip is from [#80](https://github.com/jelmer/yaml-edit/pull/80) ([`bc4349b`](https://github.com/jelmer/yaml-edit/commit/bc4349b)). TAG was not included.
